### PR TITLE
Unsafe FFI calls

### DIFF
--- a/src/Text/Parser/TreeSitter/Document.hs
+++ b/src/Text/Parser/TreeSitter/Document.hs
@@ -7,11 +7,11 @@ import Text.Parser.TreeSitter.Language
 newtype Document = Document ()
   deriving (Show, Eq)
 
-foreign import ccall "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_new" ts_document_new :: IO (Ptr Document)
-foreign import ccall "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_set_input_string" ts_document_set_input_string :: Ptr Document -> CString -> IO ()
-foreign import ccall "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_set_input_string_with_length" ts_document_set_input_string_with_length :: Ptr Document -> CString -> Int -> IO ()
-foreign import ccall "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_parse" ts_document_parse :: Ptr Document -> IO ()
-foreign import ccall "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_free" ts_document_free :: Ptr Document -> IO ()
-foreign import ccall "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_set_language" ts_document_set_language :: Ptr Document -> Ptr Language -> IO ()
+foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_new" ts_document_new :: IO (Ptr Document)
+foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_set_input_string" ts_document_set_input_string :: Ptr Document -> CString -> IO ()
+foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_set_input_string_with_length" ts_document_set_input_string_with_length :: Ptr Document -> CString -> Int -> IO ()
+foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_parse" ts_document_parse :: Ptr Document -> IO ()
+foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_free" ts_document_free :: Ptr Document -> IO ()
+foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_document_set_language" ts_document_set_language :: Ptr Document -> Ptr Language -> IO ()
 
-foreign import ccall "src/bridge.c ts_document_log_to_stderr" ts_document_log_to_stderr :: Ptr Document -> IO ()
+foreign import ccall unsafe "src/bridge.c ts_document_log_to_stderr" ts_document_log_to_stderr :: Ptr Document -> IO ()

--- a/src/Text/Parser/TreeSitter/Node.hs
+++ b/src/Text/Parser/TreeSitter/Node.hs
@@ -83,7 +83,7 @@ instance Storable TSNode where
 
 
 
-foreign import ccall "src/bridge.c ts_document_root_node_p" ts_document_root_node_p :: Ptr Document -> Ptr Node -> IO ()
+foreign import ccall unsafe "src/bridge.c ts_document_root_node_p" ts_document_root_node_p :: Ptr Document -> Ptr Node -> IO ()
 
-foreign import ccall "src/bridge.c ts_node_copy_named_child_nodes" ts_node_copy_named_child_nodes :: Ptr Document -> Ptr TSNode -> Ptr Node -> CSize -> IO ()
-foreign import ccall "src/bridge.c ts_node_copy_child_nodes" ts_node_copy_child_nodes :: Ptr Document -> Ptr TSNode -> Ptr Node -> CSize -> IO ()
+foreign import ccall unsafe "src/bridge.c ts_node_copy_named_child_nodes" ts_node_copy_named_child_nodes :: Ptr Document -> Ptr TSNode -> Ptr Node -> CSize -> IO ()
+foreign import ccall unsafe "src/bridge.c ts_node_copy_child_nodes" ts_node_copy_child_nodes :: Ptr Document -> Ptr TSNode -> Ptr Node -> CSize -> IO ()


### PR DESCRIPTION
`unsafe` means that we know that these will never call back into Haskell, and thus the runtime can skip a bunch of checks that it would otherwise need to use.

This is saving us about half a second in the case I’m testing.