### PR TITLE
Allow null document pointers

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -27,7 +27,7 @@ static inline Node ts_node_elaborate(const TSDocument *document, TSNode node) {
   return (Node){
     .node = node,
     .symbol = ts_node_symbol(node),
-    .type = ts_node_type(node, document),
+    .type = document ? ts_node_type(node, document) : NULL,
     .startPoint = ts_node_start_point(node),
     .endPoint = ts_node_end_point(node),
     .startByte = ts_node_start_byte(node),
@@ -47,7 +47,6 @@ void ts_document_root_node_p(TSDocument *document, Node *outNode) {
 
 
 void ts_node_copy_child_nodes(const TSDocument *document, const TSNode *parentNode, Node *outChildNodes, size_t count) {
-  assert(document != NULL);
   assert(parentNode != NULL);
   assert(outChildNodes != NULL);
   assert(count >= 0);
@@ -59,7 +58,6 @@ void ts_node_copy_child_nodes(const TSDocument *document, const TSNode *parentNo
 }
 
 void ts_node_copy_named_child_nodes(const TSDocument *document, const TSNode *parentNode, Node *outChildNodes, size_t count) {
-  assert(document != NULL);
   assert(parentNode != NULL);
   assert(outChildNodes != NULL);
   assert(count >= 0);


### PR DESCRIPTION
This is intended to ease some experimentation where we don’t need the production name, just the symbol (which is available as of #7).

- [x] Depends on #7.