### PR TITLE
Derive Bounded & Ix instances for grammar datatypes.

### DIFF
--- a/src/Text/Parser/TreeSitter/Language.hs
+++ b/src/Text/Parser/TreeSitter/Language.hs
@@ -2,6 +2,7 @@
 module Text.Parser.TreeSitter.Language where
 
 import Data.Char
+import Data.Ix (Ix)
 import Data.Traversable (for)
 import Data.List.Split
 import Data.Word
@@ -34,7 +35,7 @@ mkSymbolDatatype name language = do
 
   Module _ modName <- thisModule
   pure
-    [ DataD [] name [] Nothing (flip NormalC [] . mkName . uncurry symbolToName <$> symbols) [ ConT ''Show, ConT ''Eq, ConT ''Enum, ConT ''Ord, ConT ''Bounded ]
+    [ DataD [] name [] Nothing (flip NormalC [] . mkName . uncurry symbolToName <$> symbols) [ ConT ''Show, ConT ''Eq, ConT ''Enum, ConT ''Ord, ConT ''Bounded, ConT ''Ix ]
     , InstanceD Nothing [] (AppT (ConT ''Symbol) (ConT name)) [ FunD 'symbolType (uncurry (clause modName) <$> symbols) ] ]
   where clause modName symbolType str = Clause [ ConP (Name (OccName (symbolToName symbolType str)) (NameQ modName)) [] ] (NormalB (ConE (promote symbolType))) []
         promote Regular = 'Regular

--- a/src/Text/Parser/TreeSitter/Language.hs
+++ b/src/Text/Parser/TreeSitter/Language.hs
@@ -34,7 +34,7 @@ mkSymbolDatatype name language = do
 
   Module _ modName <- thisModule
   pure
-    [ DataD [] name [] Nothing (flip NormalC [] . mkName . uncurry symbolToName <$> symbols) [ ConT ''Show, ConT ''Eq, ConT ''Enum, ConT ''Ord ]
+    [ DataD [] name [] Nothing (flip NormalC [] . mkName . uncurry symbolToName <$> symbols) [ ConT ''Show, ConT ''Eq, ConT ''Enum, ConT ''Ord, ConT ''Bounded ]
     , InstanceD Nothing [] (AppT (ConT ''Symbol) (ConT name)) [ FunD 'symbolType (uncurry (clause modName) <$> symbols) ] ]
   where clause modName symbolType str = Clause [ ConP (Name (OccName (symbolToName symbolType str)) (NameQ modName)) [] ] (NormalB (ConE (promote symbolType))) []
         promote Regular = 'Regular


### PR DESCRIPTION
A `Bounded` instance allows us to bounds-check uses of `toEnum` to e.g. deal with `ERROR` productions. An `Ix` instance allows us to perform that bounds-check using the `inRange` method.