### PR TITLE
Parse errors as maximal symbol

### DIFF
--- a/src/Text/Parser/TreeSitter/Language.hs
+++ b/src/Text/Parser/TreeSitter/Language.hs
@@ -32,7 +32,7 @@ class Symbol s where
 -- | TemplateHaskell construction of a datatype for the referenced Language.
 mkSymbolDatatype :: Name -> Ptr Language -> Q [Dec]
 mkSymbolDatatype name language = do
-  symbols <- (<> [(Regular, "ParseError")]) <$> runIO (languageSymbols language)
+  symbols <- (++ [(Regular, "ParseError")]) <$> runIO (languageSymbols language)
   let namedSymbols = uncurry symbolToName <$> symbols
 
   Module _ modName <- thisModule

--- a/src/Text/Parser/TreeSitter/Language.hs
+++ b/src/Text/Parser/TreeSitter/Language.hs
@@ -37,18 +37,12 @@ mkSymbolDatatype name language = do
 
   Module _ modName <- thisModule
   pure
-    [ DataD [] name [] Nothing (flip NormalC [] . mkName <$> namedSymbols) [ ConT ''Show, ConT ''Eq, ConT ''Ord, ConT ''Bounded, ConT ''Ix ]
-    , InstanceD Nothing [] (AppT (ConT ''Symbol) (ConT name)) [ FunD 'symbolType (uncurry (clause modName) <$> symbols) ]
-    , InstanceD Nothing [] (AppT (ConT ''Enum) (ConT name))
-      [ FunD 'toEnum (zipWith (toEnumClause modName) [-1..] namedSymbols)
-      , FunD 'fromEnum (zipWith (fromEnumClause modName) [-1..] namedSymbols) ] ]
+    [ DataD [] name [] Nothing (flip NormalC [] . mkName <$> namedSymbols) [ ConT ''Show, ConT ''Enum, ConT ''Eq, ConT ''Ord, ConT ''Bounded, ConT ''Ix ]
+    , InstanceD Nothing [] (AppT (ConT ''Symbol) (ConT name)) [ FunD 'symbolType (uncurry (clause modName) <$> symbols) ] ]
   where clause modName symbolType str = Clause [ ConP (Name (OccName (symbolToName symbolType str)) (NameQ modName)) [] ] (NormalB (ConE (promote symbolType))) []
         promote Regular = 'Regular
         promote Anonymous = 'Anonymous
         promote Auxiliary = 'Auxiliary
-
-        toEnumClause modName n name = Clause [ LitP (IntegerL n) ] (NormalB (ConE (Name (OccName name) (NameQ modName)))) []
-        fromEnumClause modName n name = Clause [ ConP (Name (OccName name) (NameQ modName)) [] ] (NormalB (LitE (IntegerL n))) []
 
 languageSymbols :: Ptr Language -> IO [(SymbolType, String)]
 languageSymbols language = for [0..fromIntegral (pred count)] $ \ symbol -> do

--- a/src/Text/Parser/TreeSitter/Language.hs
+++ b/src/Text/Parser/TreeSitter/Language.hs
@@ -32,7 +32,7 @@ class Symbol s where
 -- | TemplateHaskell construction of a datatype for the referenced Language.
 mkSymbolDatatype :: Name -> Ptr Language -> Q [Dec]
 mkSymbolDatatype name language = do
-  symbols <- ((Regular, "ParseError") :) <$> runIO (languageSymbols language)
+  symbols <- (<> [(Regular, "ParseError")]) <$> runIO (languageSymbols language)
   let namedSymbols = uncurry symbolToName <$> symbols
 
   Module _ modName <- thisModule


### PR DESCRIPTION
This PR places the `ParseError` constructor at the end, and resumes deriving the `Enum` instance, fixing the mismatch between unsigned `TSSymbol` values and the `ParseError` constructor, at the cost of requiring a bounds check on `nodeSymbol` before using `toEnum`.