### PR TITLE
Name constructors uniquely

### DIFF
--- a/src/Text/Parser/TreeSitter/Language.hs
+++ b/src/Text/Parser/TreeSitter/Language.hs
@@ -3,6 +3,7 @@ module Text.Parser.TreeSitter.Language where
 
 import Prelude
 import Data.Char
+import Data.Function ((&))
 import Data.Ix (Ix)
 import Data.Traversable (for)
 import Data.List.Split
@@ -56,7 +57,14 @@ languageSymbols language = for [0..fromIntegral (pred count)] $ \ symbol -> do
   where count = ts_language_symbol_count language
 
 symbolToName :: SymbolType -> String -> (SymbolType, String)
-symbolToName ty = (,) ty . (prefix ++) . (>>= initUpper) . map (>>= toDescription) . filter (not . all (== '_')) . toWords . prefixHidden
+symbolToName ty name
+  = prefixHidden name
+  & toWords
+  & filter (not . all (== '_'))
+  & map (>>= toDescription)
+  & (>>= initUpper)
+  & (prefix ++)
+  & (,) ty
   where toWords = split (condense (whenElt (not . isAlpha)))
 
         prefixHidden s@('_':_) = "Hidden" ++ s

--- a/src/Text/Parser/TreeSitter/Language.hs
+++ b/src/Text/Parser/TreeSitter/Language.hs
@@ -34,7 +34,7 @@ class Symbol s where
 mkSymbolDatatype :: Name -> Ptr Language -> Q [Dec]
 mkSymbolDatatype name language = do
   symbols <- (++ [(Regular, "ParseError")]) <$> runIO (languageSymbols language)
-  let namedSymbols = nub (uncurry symbolToName <$> symbols)
+  let namedSymbols = uncurry symbolToName <$> symbols
 
   Module _ modName <- thisModule
   pure


### PR DESCRIPTION
With `alias` rules we produce symbols of the same name multiple times. This prevents duplicate symbol names from occurring in the named symbols returned from haskell tree sitter for a given tree-sitter grammar.

Duplicate symbols' names are updated with a `'` to maintain uniqueness.

🎩  @robrix for 🍐  and deep dive.