### PR TITLE
Simplify the module hierarchy.

### DIFF
--- a/haskell-tree-sitter.cabal
+++ b/haskell-tree-sitter.cabal
@@ -21,10 +21,10 @@ library
                      , template-haskell >= 2.12 && < 2.13
   default-language:    Haskell2010
   default-extensions:  FlexibleInstances, OverloadedStrings, NoImplicitPrelude, RecordWildCards
-  exposed-modules:     Text.Parser.TreeSitter
-                     , Text.Parser.TreeSitter.Document
-                     , Text.Parser.TreeSitter.Language
-                     , Text.Parser.TreeSitter.Node
+  exposed-modules:     TreeSitter
+                     , TreeSitter.Document
+                     , TreeSitter.Language
+                     , TreeSitter.Node
   c-sources:           src/bridge.c
                      , vendor/tree-sitter/src/runtime/document.c
                      , vendor/tree-sitter/src/runtime/error_costs.c

--- a/haskell-tree-sitter.cabal
+++ b/haskell-tree-sitter.cabal
@@ -21,8 +21,7 @@ library
                      , template-haskell >= 2.12 && < 2.13
   default-language:    Haskell2010
   default-extensions:  FlexibleInstances, OverloadedStrings, NoImplicitPrelude, RecordWildCards
-  exposed-modules:     TreeSitter
-                     , TreeSitter.Document
+  exposed-modules:     TreeSitter.Document
                      , TreeSitter.Language
                      , TreeSitter.Node
   c-sources:           src/bridge.c

--- a/src/Text/Parser/TreeSitter.hs
+++ b/src/Text/Parser/TreeSitter.hs
@@ -1,5 +1,0 @@
-module Text.Parser.TreeSitter (module TS) where
-
-import Text.Parser.TreeSitter.Document as TS
-import Text.Parser.TreeSitter.Language as TS
-import Text.Parser.TreeSitter.Node as TS

--- a/src/TreeSitter/Document.hs
+++ b/src/TreeSitter/Document.hs
@@ -1,9 +1,9 @@
-module Text.Parser.TreeSitter.Document where
+module TreeSitter.Document where
 
 import Prelude
 import Foreign
 import Foreign.C
-import Text.Parser.TreeSitter.Language
+import TreeSitter.Language
 
 newtype Document = Document ()
   deriving (Show, Eq)

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
-module Text.Parser.TreeSitter.Language where
+module TreeSitter.Language where
 
 import Prelude
 import Data.Char

--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE DeriveGeneric, DeriveAnyClass, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
-module Text.Parser.TreeSitter.Node where
+module TreeSitter.Node where
 
 import Prelude
 import Foreign
 import Foreign.C
 import Foreign.CStorable
 import GHC.Generics
-import Text.Parser.TreeSitter.Document
+import TreeSitter.Document
 
 data Node = Node
   { nodeTSNode :: !TSNode


### PR DESCRIPTION
This PR removes the `Text.Parser` prefix from the modules.