### PR TITLE
Allow adding of relative, dependent files for TH

### DIFF
--- a/haskell-tree-sitter.cabal
+++ b/haskell-tree-sitter.cabal
@@ -17,6 +17,8 @@ library
   hs-source-dirs:      src
   build-depends:       base >= 4.7 && < 5
                      , c-storable-deriving
+                     , directory
+                     , filepath
                      , split
                      , template-haskell >= 2.12 && < 2.13
   default-language:    Haskell2010


### PR DESCRIPTION
This lets languages easily specify various files that they might be dependent on so that, for example, `mkSymbolDatatype` will re-run when something in the tree-sitter grammar has changed.