### PR TITLE
Symbol superclasses

### DIFF
--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -29,7 +29,7 @@ foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts
 foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
 
 
-class Symbol s where
+class Enum s => Symbol s where
   symbolType :: s -> SymbolType
 
 

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -29,7 +29,7 @@ foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts
 foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
 
 
-class (Bounded s, Enum s, Ix s, Ord s) => Symbol s where
+class (Bounded s, Enum s, Ix s, Ord s, Show s) => Symbol s where
   symbolType :: s -> SymbolType
 
 

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -29,7 +29,7 @@ foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts
 foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
 
 
-class (Enum s, Ord s) => Symbol s where
+class (Bounded s, Enum s, Ord s) => Symbol s where
   symbolType :: s -> SymbolType
 
 

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -29,7 +29,7 @@ foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts
 foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
 
 
-class (Bounded s, Enum s, Ord s) => Symbol s where
+class (Bounded s, Enum s, Ix s, Ord s) => Symbol s where
   symbolType :: s -> SymbolType
 
 

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -29,7 +29,7 @@ foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts
 foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
 
 
-class Enum s => Symbol s where
+class (Enum s, Ord s) => Symbol s where
   symbolType :: s -> SymbolType
 
 


### PR DESCRIPTION
This PR gives `Symbol` a bunch of superclasses that we need basically any time we’re using them.