### PR TITLE
Add stack files to prevent haskell-tree-sitter from rebuilding

### DIFF
--- a/languages/go/stack.yaml
+++ b/languages/go/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- '../../'
+extra-deps:
+- c-storable-deriving-0.1.3
+resolver: nightly-2017-09-10

--- a/languages/json/stack.yaml
+++ b/languages/json/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- '../../'
+extra-deps:
+- c-storable-deriving-0.1.3
+resolver: nightly-2017-09-10

--- a/languages/python/stack.yaml
+++ b/languages/python/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- '../../'
+extra-deps:
+- c-storable-deriving-0.1.3
+resolver: nightly-2017-09-10

--- a/languages/ruby/stack.yaml
+++ b/languages/ruby/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- '../../'
+extra-deps:
+- c-storable-deriving-0.1.3
+resolver: nightly-2017-09-10

--- a/languages/typescript/stack.yaml
+++ b/languages/typescript/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- '../../'
+extra-deps:
+- c-storable-deriving-0.1.3
+resolver: nightly-2017-09-10

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,17 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- location: languages/go
+  extra-dep: true
+- location: languages/python
+  extra-dep: true
+- location: languages/typescript
+  extra-dep: true
+- location: languages/json
+  extra-dep: true
+- location: languages/ruby
+  extra-dep: true
+extra-deps:
+- c-storable-deriving-0.1.3
+resolver: nightly-2017-09-10


### PR DESCRIPTION
It seems stack needs these in order to prevent rebuilding when running `stack build` multiple times.