### PR TITLE
Add support for cancelling an in-flight parse.

### DIFF
--- a/src/TreeSitter/Parser.hs
+++ b/src/TreeSitter/Parser.hs
@@ -14,4 +14,6 @@ foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_p
 foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_parse_string" ts_parser_parse_string :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)
 foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_delete" ts_parser_delete :: Ptr Parser -> IO ()
 foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO ()
+foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_enabled" ts_parser_enabled :: Ptr Parser -> IO CBool
+foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_set_enabled" ts_parser_set_enabled :: Ptr Parser -> CBool -> IO ()
 foreign import ccall safe "src/bridge.c ts_parser_log_to_stderr" ts_parser_log_to_stderr :: Ptr Parser -> IO ()

--- a/src/TreeSitter/Parser.hs
+++ b/src/TreeSitter/Parser.hs
@@ -16,4 +16,6 @@ foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_p
 foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO ()
 foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_enabled" ts_parser_enabled :: Ptr Parser -> IO CBool
 foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_set_enabled" ts_parser_set_enabled :: Ptr Parser -> CBool -> IO ()
+
 foreign import ccall safe "src/bridge.c ts_parser_log_to_stderr" ts_parser_log_to_stderr :: Ptr Parser -> IO ()
+foreign import ccall safe "src/bridge.c ts_parser_loop_until_cancelled" ts_parser_loop_until_cancelled :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -54,6 +54,16 @@ void ts_node_copy_child_nodes(const TSNode *parentNode, Node *outChildNodes, siz
   }
 }
 
+// For testing cancellation from Haskell.
+// Has the same signature as ts_parser_parse_string for convenience.
+TSTree *ts_parser_loop_until_cancelled(TSParser *self, const TSTree *old_tree, const char* string, uint32_t length)
+{
+  while (ts_parser_enabled(self)) {
+
+  }
+  return NULL;
+}
+
 size_t sizeof_tsnode() {
   return sizeof(TSNode);
 }


### PR DESCRIPTION
Hooks into `ts_parser_enabled` and `ts_parser_set_enabled`. Bumps tree-sitter.