### PR TITLE
Add tree-sitter-haskell bindings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "languages/php/vendor/tree-sitter-php"]
 	path = languages/php/vendor/tree-sitter-php
 	url = https://github.com/tree-sitter/tree-sitter-php
+[submodule "languages/haskell/vendor/tree-sitter-haskell"]
+	path = languages/haskell/vendor/tree-sitter-haskell
+	url = https://github.com/tree-sitter/tree-sitter-haskell.git

--- a/haskell-tree-sitter.cabal
+++ b/haskell-tree-sitter.cabal
@@ -5,7 +5,7 @@ description:         Please see README.md
 homepage:            http://github.com/tree-sitter/haskell-tree-sitter#readme
 license:             BSD3
 license-file:        LICENSE
-author:              Rob Rix, Josh Vera, Tim Clem, Rick Winfrey, Max Brunsfeld
+author:              Rob Rix, Josh Vera, Tim Clem, Rick Winfrey, Max Brunsfeld, Ayman Nadeem, Patrick Thomson
 maintainer:          rob.rix@github.com
 copyright:           2015 GitHub
 category:            Web

--- a/languages/go/tree-sitter-go.cabal
+++ b/languages/go/tree-sitter-go.cabal
@@ -3,7 +3,7 @@ version:             0.1.0
 synopsis:            tree-sitter go language bindings
 description:         Please see README.md
 homepage:            https://github.com/tree-sitter/tree-sitter-go#readme
-author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          tclem@github.com
 copyright:           2017 GitHub
 category:            Web

--- a/languages/haskell/Setup.hs
+++ b/languages/haskell/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/languages/haskell/TreeSitter/Haskell.hs
+++ b/languages/haskell/TreeSitter/Haskell.hs
@@ -1,0 +1,8 @@
+module TreeSitter.Haskell
+( tree_sitter_haskell
+) where
+
+import Foreign.Ptr
+import TreeSitter.Language
+
+foreign import ccall unsafe "vendor/tree-sitter-haskell/src/parser.c tree_sitter_haskell" tree_sitter_haskell :: Ptr Language

--- a/languages/haskell/cabal.project
+++ b/languages/haskell/cabal.project
@@ -1,0 +1,2 @@
+packages: ./
+jobs: $ncpus

--- a/languages/haskell/stack.yaml
+++ b/languages/haskell/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- '../../'
+extra-deps:
+- c-storable-deriving-0.1.3
+resolver: nightly-2017-09-10

--- a/languages/haskell/tree-sitter-haskell.cabal
+++ b/languages/haskell/tree-sitter-haskell.cabal
@@ -1,0 +1,25 @@
+name:                tree-sitter-haskell
+version:             0.1.0
+synopsis:            tree-sitter haskell language bindings
+description:         Please see README.md
+homepage:            https://github.com/tree-sitter/tree-sitter-haskell#readme
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
+maintainer:          tclem@github.com
+copyright:           2017 GitHub
+category:            Web
+build-type:          Simple
+-- extra-source-files:
+cabal-version:       >=1.10
+
+library
+  exposed-modules:     TreeSitter.Ruby
+  build-depends:       base >= 4.7 && < 5
+                     , haskell-tree-sitter
+  default-language:    Haskell2010
+  c-sources:           vendor/tree-sitter-haskell/src/parser.c
+                     , vendor/tree-sitter-haskell/src/scanner.cc
+  extra-libraries:     stdc++
+
+source-repository head
+  type:     git
+  location: https://github.com/tree-sitter/tree-sitter-haskell

--- a/languages/haskell/tree-sitter-haskell.cabal
+++ b/languages/haskell/tree-sitter-haskell.cabal
@@ -12,7 +12,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     TreeSitter.Ruby
+  exposed-modules:     TreeSitter.Haskell
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010

--- a/languages/json/tree-sitter-json.cabal
+++ b/languages/json/tree-sitter-json.cabal
@@ -3,7 +3,7 @@ version:             0.1.0
 synopsis:            tree-sitter json language bindings
 description:         Please see README.md
 homepage:            https://github.com/tree-sitter/tree-sitter-json#readme
-author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          vera@github.com
 copyright:           2017 GitHub
 category:            Web

--- a/languages/php/tree-sitter-php.cabal
+++ b/languages/php/tree-sitter-php.cabal
@@ -3,7 +3,7 @@ version:             0.1.0
 synopsis:            tree-sitter php language bindings
 description:         Please see README.md
 homepage:            https://github.com/tree-sitter/tree-sitter-php#readme
-author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          vera@github.com
 copyright:           2017 GitHub
 category:            Web

--- a/languages/python/tree-sitter-python.cabal
+++ b/languages/python/tree-sitter-python.cabal
@@ -3,7 +3,7 @@ version:             0.1.0
 synopsis:            tree-sitter python language bindings
 description:         Please see README.md
 homepage:            https://github.com/tree-sitter/tree-sitter-python#readme
-author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          tclem@github.com
 copyright:           2017 GitHub
 category:            Web

--- a/languages/ruby/tree-sitter-ruby.cabal
+++ b/languages/ruby/tree-sitter-ruby.cabal
@@ -3,7 +3,7 @@ version:             0.1.0
 synopsis:            tree-sitter ruby language bindings
 description:         Please see README.md
 homepage:            https://github.com/tree-sitter/tree-sitter-ruby#readme
-author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          tclem@github.com
 copyright:           2017 GitHub
 category:            Web

--- a/languages/typescript/tree-sitter-typescript.cabal
+++ b/languages/typescript/tree-sitter-typescript.cabal
@@ -3,7 +3,7 @@ version:             0.1.0
 synopsis:            tree-sitter typescript language bindings
 description:         Please see README.md
 homepage:            https://github.com/tree-sitter/tree-sitter-typescript#readme
-author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          vera@github.com
 copyright:           2017 GitHub
 category:            Web

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 module TreeSitter.Language where
 
-import Prelude
 import Data.Char
 import Data.Function ((&))
 import Data.Ix (Ix)

--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -7,7 +7,6 @@ module TreeSitter.Node
 , ts_node_copy_child_nodes
 ) where
 
-import Prelude
 import Foreign
 import Foreign.C
 import GHC.Generics

--- a/src/TreeSitter/Parser.hs
+++ b/src/TreeSitter/Parser.hs
@@ -1,6 +1,5 @@
 module TreeSitter.Parser where
 
-import Prelude
 import Foreign
 import Foreign.C
 import TreeSitter.Language

--- a/src/TreeSitter/Tree.hs
+++ b/src/TreeSitter/Tree.hs
@@ -1,6 +1,5 @@
 module TreeSitter.Tree where
 
-import Prelude
 import Foreign
 import TreeSitter.Node
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,4 +14,6 @@ packages:
   extra-dep: true
 - location: languages/ruby
   extra-dep: true
+- location: languages/haskell
+  extra-dep: true
 resolver: lts-10.0


### PR DESCRIPTION
Also updates the author field in all cabal files to add @aymannadeem and @patrickt 😄 

@robrix, I've also removed the Prelude imports statements from the `TreeSitter` modules.