### PR TITLE
Mark ts_node_copy_child_nodes as interruptible from Haskell.

### DIFF
--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass, InterruptibleFFI, RankNTypes, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 module TreeSitter.Node
 ( Node(..)
@@ -126,4 +126,4 @@ instance Monad Struct where
   {-# INLINE (>>=) #-}
 
 
-foreign import ccall unsafe "src/bridge.c ts_node_copy_child_nodes" ts_node_copy_child_nodes :: Ptr TSNode -> Ptr Node -> CSize -> IO ()
+foreign import ccall interruptible "src/bridge.c ts_node_copy_child_nodes" ts_node_copy_child_nodes :: Ptr TSNode -> Ptr Node -> CSize -> IO ()


### PR DESCRIPTION
Given certain pathological input, such as an array literal with 150000
elements, the ts_node_copy_child_nodes function can take an extremely
long time. While we may be able to make this more performant,
fundamentally this is a situation where a client should use a timeout.

Unfortunately, because this function is called via the FFI, `timeout`
will not properly interrupt a call to ts_node_copy_child_nodes, as
per the GHC manual:

> Normally when the target of a throwTo is involved in a foreign call,
> the exception is not raised until the call returns, and in the
> meantime the caller is blocked. This can result in unresponsiveness,
> which is particularly undesirable in the case of user
> interrupt (e.g. Control-C).

We have two options here: we can either change
ts_node_copy_child_nodes to take a `TSParser*` and check, in the
internal for-loop, whether the parser has been marked as cancelled.
Alternatively, we can mark the call as `interruptible` with the
`InterruptibleFFI` extension, which means that GHC will use an OS
thread to run this FFI call, and will hit that call with
`pthread_kill()` if it is targeted with a `throwTo` in a timeout.

I've gone with the second option, as it involves less API churn and
avoids the overhead of checking for cancellation every iteration of
the loop. If you think the first option is better, please let me know:
I think this approach is fine, though I would use cancellation if this
were an official tree-sitter API.