### PR TITLE
Inline and avoid partial application in evalStruct.

### DIFF
--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -33,7 +33,8 @@ data TSNode = TSNode !Word32 !Word32 !Word32 !Word32 !(Ptr ()) !(Ptr ())
 newtype Struct a = Struct { runStruct :: forall b . Ptr b -> IO (a, Ptr a) }
 
 evalStruct :: Struct a -> Ptr b -> IO a
-evalStruct = fmap (fmap fst) . runStruct
+evalStruct s p = fmap fst $! runStruct s p
+{-# INLINE evalStruct #-}
 
 peekStruct :: forall a . Storable a => Struct a
 peekStruct = Struct (\ p -> do


### PR DESCRIPTION
Since the `Storable` instance for `Node` is implemented in terms of
the `evalStruct` function, it behooves us to avoid partial application
and function composition in its definition, as partially-applied
functions are slower than fully-applied ones.

When compiling with -O0, this produces _drastically_ faster parses on
large files: on a 5MB Go file parses went from 17sec to 7sec. The
improvement is less noticeable on when compiling with -O2, but is
still present (~0.5sec).