### PR TITLE
Update Tree-sitter, expose new timeout API

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,28 +1,2 @@
-import Data.Maybe
-import qualified Distribution.PackageDescription as P
 import Distribution.Simple
-import Distribution.Simple.LocalBuildInfo
-import Distribution.Simple.Setup
-import System.Directory
-
-main :: IO ()
-main = defaultMainWithHooks simpleUserHooks { confHook = conf }
-
-conf :: (P.GenericPackageDescription, P.HookedBuildInfo) -> ConfigFlags -> IO LocalBuildInfo
-conf x flags = do
-  localBuildInfo <- confHook simpleUserHooks x flags
-  let packageDescription = localPkgDescr localBuildInfo
-      library = fromJust $ P.library packageDescription
-      libraryBuildInfo = P.libBuildInfo library
-      relativeIncludeDirs = [ "include", "src", "externals/utf8proc" ] in do
-      dir <- getCurrentDirectory
-      putStrLn $ "[debug] configuring haskell-tree-sitter within directory: " ++ dir
-      return localBuildInfo {
-        localPkgDescr = packageDescription {
-          P.library = Just $ library {
-            P.libBuildInfo = libraryBuildInfo {
-              P.includeDirs = (((dir ++ "/vendor/tree-sitter/") ++) <$> relativeIncludeDirs) ++ P.includeDirs libraryBuildInfo
-            }
-          }
-        }
-      }
+main = defaultMain

--- a/haskell-tree-sitter.cabal
+++ b/haskell-tree-sitter.cabal
@@ -26,21 +26,14 @@ library
                      , TreeSitter.Node
                      , TreeSitter.Tree
                      , TreeSitter.Ptr
-  Include-dirs:        includes                     
-  Includes:            tree_sitter_ptr.h                     
+  Include-dirs:        includes
+                     , vendor/tree-sitter/lib/include
+                     , vendor/tree-sitter/lib/src
+                     , vendor/tree-sitter/lib/utf8proc
+  Includes:            tree_sitter_ptr.h
   c-sources:           src/bridge.c
                      , src/bridge_ptr.c
-                     , vendor/tree-sitter/externals/utf8proc/utf8proc.c
-                     , vendor/tree-sitter/src/runtime/get_changed_ranges.c
-                     , vendor/tree-sitter/src/runtime/language.c
-                     , vendor/tree-sitter/src/runtime/lexer.c
-                     , vendor/tree-sitter/src/runtime/node.c
-                     , vendor/tree-sitter/src/runtime/parser.c
-                     , vendor/tree-sitter/src/runtime/stack.c
-                     , vendor/tree-sitter/src/runtime/subtree.c
-                     , vendor/tree-sitter/src/runtime/tree.c
-                     , vendor/tree-sitter/src/runtime/tree_cursor.c
-                     , vendor/tree-sitter/src/runtime/utf16.c
+                     , vendor/tree-sitter/lib/src/lib.c
   cc-options:          -std=c99 -Os
   ghc-options:         -Wall -fno-warn-name-shadowing -O -j
 

--- a/includes/tree_sitter_ptr.h
+++ b/includes/tree_sitter_ptr.h
@@ -1,4 +1,4 @@
-#include "tree_sitter/runtime.h"
+#include "tree_sitter/api.h"
 
 /* TODO put TSTreeCursor etc. here ! */
 typedef struct {

--- a/languages/go/tree-sitter-go.cabal
+++ b/languages/go/tree-sitter-go.cabal
@@ -16,6 +16,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-go/src
   c-sources:           vendor/tree-sitter-go/src/parser.c
 
 source-repository head

--- a/languages/haskell/tree-sitter-haskell.cabal
+++ b/languages/haskell/tree-sitter-haskell.cabal
@@ -37,6 +37,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-haskell/src
   c-sources:           vendor/tree-sitter-haskell/src/parser.c
                      , vendor/tree-sitter-haskell/src/scanner.cc
   extra-libraries:     stdc++

--- a/languages/java/tree-sitter-java.cabal
+++ b/languages/java/tree-sitter-java.cabal
@@ -16,6 +16,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-java/src
   c-sources:           vendor/tree-sitter-java/src/parser.c
   extra-libraries:     stdc++
 

--- a/languages/json/tree-sitter-json.cabal
+++ b/languages/json/tree-sitter-json.cabal
@@ -16,6 +16,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-json/src
   c-sources:           vendor/tree-sitter-json/src/parser.c
 
 source-repository head

--- a/languages/php/tree-sitter-php.cabal
+++ b/languages/php/tree-sitter-php.cabal
@@ -16,6 +16,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-php/src
   c-sources:           vendor/tree-sitter-php/src/parser.c
                      , vendor/tree-sitter-php/src/scanner.cc
   extra-libraries:     stdc++

--- a/languages/python/tree-sitter-python.cabal
+++ b/languages/python/tree-sitter-python.cabal
@@ -16,6 +16,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-python/src
   c-sources:           vendor/tree-sitter-python/src/parser.c
                      , vendor/tree-sitter-python/src/scanner.cc
   extra-libraries:     stdc++

--- a/languages/ruby/tree-sitter-ruby.cabal
+++ b/languages/ruby/tree-sitter-ruby.cabal
@@ -16,6 +16,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-ruby/src
   c-sources:           vendor/tree-sitter-ruby/src/parser.c
                      , vendor/tree-sitter-ruby/src/scanner.cc
   extra-libraries:     stdc++

--- a/languages/typescript/tree-sitter-typescript.cabal
+++ b/languages/typescript/tree-sitter-typescript.cabal
@@ -16,6 +16,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , haskell-tree-sitter
   default-language:    Haskell2010
+  Include-dirs:        vendor/tree-sitter-typescript/src
   c-sources:           vendor/tree-sitter-typescript/src/parser.c
                      , vendor/tree-sitter-typescript/src/scanner.c
 

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -22,9 +22,9 @@ type TSSymbol = Word16
 data SymbolType = Regular | Anonymous | Auxiliary
   deriving (Enum, Eq, Ord, Show)
 
-foreign import ccall unsafe "api.h ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> Word32
-foreign import ccall unsafe "api.h ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> CString
-foreign import ccall unsafe "api.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
+foreign import ccall unsafe "ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> Word32
+foreign import ccall unsafe "ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> CString
+foreign import ccall unsafe "ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
 
 
 class (Bounded s, Enum s, Ix s, Ord s, Show s) => Symbol s where

--- a/src/TreeSitter/Language.hs
+++ b/src/TreeSitter/Language.hs
@@ -22,9 +22,9 @@ type TSSymbol = Word16
 data SymbolType = Regular | Anonymous | Auxiliary
   deriving (Enum, Eq, Ord, Show)
 
-foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> Word32
-foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> CString
-foreign import ccall unsafe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
+foreign import ccall unsafe "api.h ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> Word32
+foreign import ccall unsafe "api.h ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> CString
+foreign import ccall unsafe "api.h ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
 
 
 class (Bounded s, Enum s, Ix s, Ord s, Show s) => Symbol s where

--- a/src/TreeSitter/Parser.hs
+++ b/src/TreeSitter/Parser.hs
@@ -8,13 +8,12 @@ import TreeSitter.Tree
 newtype Parser = Parser ()
   deriving (Show, Eq)
 
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_new" ts_parser_new :: IO (Ptr Parser)
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_halt_on_error" ts_parser_halt_on_error :: Ptr Parser -> CBool -> IO ()
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_parse_string" ts_parser_parse_string :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_delete" ts_parser_delete :: Ptr Parser -> IO ()
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO ()
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_enabled" ts_parser_enabled :: Ptr Parser -> IO CBool
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_parser_set_enabled" ts_parser_set_enabled :: Ptr Parser -> CBool -> IO ()
+foreign import ccall safe "api.h ts_parser_new" ts_parser_new :: IO (Ptr Parser)
+foreign import ccall safe "api.h ts_parser_halt_on_error" ts_parser_halt_on_error :: Ptr Parser -> CBool -> IO ()
+foreign import ccall safe "api.h ts_parser_parse_string" ts_parser_parse_string :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)
+foreign import ccall safe "api.h ts_parser_delete" ts_parser_delete :: Ptr Parser -> IO ()
+foreign import ccall safe "api.h ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO ()
+foreign import ccall safe "api.h ts_parser_timeout_micros" ts_parser_timeout_micros :: Ptr Parser -> IO Word64
+foreign import ccall safe "api.h ts_parser_set_timeout_micros" ts_parser_set_timeout_micros :: Ptr Parser -> Word64 -> IO ()
 
 foreign import ccall safe "src/bridge.c ts_parser_log_to_stderr" ts_parser_log_to_stderr :: Ptr Parser -> IO ()
-foreign import ccall safe "src/bridge.c ts_parser_loop_until_cancelled" ts_parser_loop_until_cancelled :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)

--- a/src/TreeSitter/Parser.hs
+++ b/src/TreeSitter/Parser.hs
@@ -8,12 +8,12 @@ import TreeSitter.Tree
 newtype Parser = Parser ()
   deriving (Show, Eq)
 
-foreign import ccall safe "api.h ts_parser_new" ts_parser_new :: IO (Ptr Parser)
-foreign import ccall safe "api.h ts_parser_halt_on_error" ts_parser_halt_on_error :: Ptr Parser -> CBool -> IO ()
-foreign import ccall safe "api.h ts_parser_parse_string" ts_parser_parse_string :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)
-foreign import ccall safe "api.h ts_parser_delete" ts_parser_delete :: Ptr Parser -> IO ()
-foreign import ccall safe "api.h ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO ()
-foreign import ccall safe "api.h ts_parser_timeout_micros" ts_parser_timeout_micros :: Ptr Parser -> IO Word64
-foreign import ccall safe "api.h ts_parser_set_timeout_micros" ts_parser_set_timeout_micros :: Ptr Parser -> Word64 -> IO ()
+foreign import ccall safe "ts_parser_new" ts_parser_new :: IO (Ptr Parser)
+foreign import ccall safe "ts_parser_halt_on_error" ts_parser_halt_on_error :: Ptr Parser -> CBool -> IO ()
+foreign import ccall safe "ts_parser_parse_string" ts_parser_parse_string :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)
+foreign import ccall safe "ts_parser_delete" ts_parser_delete :: Ptr Parser -> IO ()
+foreign import ccall safe "ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO ()
+foreign import ccall safe "ts_parser_timeout_micros" ts_parser_timeout_micros :: Ptr Parser -> IO Word64
+foreign import ccall safe "ts_parser_set_timeout_micros" ts_parser_set_timeout_micros :: Ptr Parser -> Word64 -> IO ()
 
 foreign import ccall safe "src/bridge.c ts_parser_log_to_stderr" ts_parser_log_to_stderr :: Ptr Parser -> IO ()

--- a/src/TreeSitter/Ptr.hsc
+++ b/src/TreeSitter/Ptr.hsc
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface, EmptyDataDecls #-}
 
-#include "tree_sitter/runtime.h"
+#include "tree_sitter/api.h"
 #include <tree_sitter_ptr.h>
 
 #if __GLASGOW_HASKELL__ < 800

--- a/src/TreeSitter/Tree.hs
+++ b/src/TreeSitter/Tree.hs
@@ -6,5 +6,5 @@ import TreeSitter.Node
 newtype Tree = Tree ()
   deriving (Show, Eq)
 
-foreign import ccall safe "api.h ts_tree_delete" ts_tree_delete :: Ptr Tree -> IO ()
+foreign import ccall safe "ts_tree_delete" ts_tree_delete :: Ptr Tree -> IO ()
 foreign import ccall unsafe "src/bridge.c ts_tree_root_node_p" ts_tree_root_node_p :: Ptr Tree -> Ptr Node -> IO ()

--- a/src/TreeSitter/Tree.hs
+++ b/src/TreeSitter/Tree.hs
@@ -6,5 +6,5 @@ import TreeSitter.Node
 newtype Tree = Tree ()
   deriving (Show, Eq)
 
-foreign import ccall safe "vendor/tree-sitter/include/tree_sitter/runtime.h ts_tree_delete" ts_tree_delete :: Ptr Tree -> IO ()
+foreign import ccall safe "api.h ts_tree_delete" ts_tree_delete :: Ptr Tree -> IO ()
 foreign import ccall unsafe "src/bridge.c ts_tree_root_node_p" ts_tree_root_node_p :: Ptr Tree -> Ptr Node -> IO ()

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -1,4 +1,4 @@
-#include "tree_sitter/runtime.h"
+#include "tree_sitter/api.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -55,16 +55,6 @@ void ts_node_copy_child_nodes(const TSNode *parentNode, Node *outChildNodes) {
   }
 
   ts_tree_cursor_delete(&curse);
-}
-
-// For testing cancellation from Haskell.
-// Has the same signature as ts_parser_parse_string for convenience.
-TSTree *ts_parser_loop_until_cancelled(TSParser *self, const TSTree *old_tree, const char* string, uint32_t length)
-{
-  while (ts_parser_enabled(self)) {
-
-  }
-  return NULL;
 }
 
 size_t sizeof_tsnode() {

--- a/src/bridge_ptr.c
+++ b/src/bridge_ptr.c
@@ -1,4 +1,4 @@
-#include "tree_sitter/runtime.h"
+#include "tree_sitter/api.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,6 +3,7 @@ import Foreign.C.Types
 import Foreign.Storable
 import Test.Hspec
 import TreeSitter.Node
+import TreeSitter.Parser
 
 main :: IO ()
 main = hspec $ do
@@ -26,6 +27,16 @@ main = hspec $ do
 
     it "roundtrips correctly" $
       with (Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8) peek `shouldReturn` Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8
+
+  describe "Parser" $ do
+    it "stores a timeout value" $ do
+      parser <- ts_parser_new
+      timeout <- ts_parser_timeout_micros parser
+      timeout `shouldBe` 0
+      ts_parser_set_timeout_micros parser 1000
+      timeout <- ts_parser_timeout_micros parser
+      timeout `shouldBe` 1000
+      ts_parser_delete parser
 
 foreign import ccall unsafe "src/bridge.c sizeof_tsnode" sizeof_tsnode :: CSize
 foreign import ccall unsafe "src/bridge.c sizeof_tspoint" sizeof_tspoint :: CSize


### PR DESCRIPTION
Now that https://github.com/tree-sitter/tree-sitter/pull/301 is done, we have a simpler way to impose timeouts on parsing.

This PR updates the Tree-sitter submodule and exposes the new timeout functions. I've also removed the `set_enabled` functions, because those underlying Tree-sitter functions were changed in https://github.com/tree-sitter/tree-sitter/pull/306.