### PR TITLE
Hide tree-sitter-haskell examples behind a cabal flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ The interface is somewhat low-level: if you use this package, you'll
 probably want to add a step that munges a given `TreeSitter.Node` into
 a more Haskell-amenable data structure.
 
-An example of using this library to parse, read, and print out AST nodes
-can be found [here](https://github.com/tree-sitter/haskell-tree-sitter/blob/master/languages/haskell/examples/Demo.hs)
+There are some example executables provided with this project:
 
-An example of using this library's experimental API to parse, navigate, read, and print out AST nodes
+* An example of using this library to parse, read, and print out AST nodes
+can be found [here](https://github.com/tree-sitter/haskell-tree-sitter/blob/master/languages/haskell/examples/Demo.hs)
+* An example of using this library's experimental API to parse, navigate, read, and print out AST nodes
 can be found [here](https://github.com/tree-sitter/haskell-tree-sitter/blob/master/languages/haskell/examples/DemoPtr.hs)
+
+To build these executables, pass the `build-examples` flag to your build tool.
 
 [tree-sitter]: https://github.com/tree-sitter/tree-sitter
 
@@ -31,4 +34,4 @@ can be found [here](https://github.com/tree-sitter/haskell-tree-sitter/blob/mast
 
 1. Run `script/bootstrap` to pull in all submodules.
 2. Adjust `stack.yaml`'s `resolver` field to target whatever LTS you want.
-3. `stack build`.
+3. `stack build` (or `stack build --flag tree-sitter-haskell:build-examples`)

--- a/languages/haskell/tree-sitter-haskell.cabal
+++ b/languages/haskell/tree-sitter-haskell.cabal
@@ -11,8 +11,14 @@ build-type:          Simple
 -- extra-source-files:
 cabal-version:       >=1.10
 
+flag build-examples
+  description: Build tree-sitter-haskell examples.
+  default:     False
+
 executable demo
   main-is: Demo.hs
+  if !flag(build-examples)
+    buildable: False
   hs-source-dirs:
       examples
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
@@ -24,6 +30,8 @@ executable demo
 
 executable demo-ptr
   main-is: DemoPtr.hs
+  if !flag(build-examples)
+    buildable: False
   hs-source-dirs:
       examples
   build-depends:


### PR DESCRIPTION
These are taking up unnecessary time on the builders.

To build with these on, do `stack build --flag tree-sitter-haskell:build-examples`