### PR TITLE
Cursor API

### DIFF
--- a/haskell-tree-sitter.cabal
+++ b/haskell-tree-sitter.cabal
@@ -26,6 +26,7 @@ library
                      , TreeSitter.Node
                      , TreeSitter.Tree
                      , TreeSitter.Ptr
+                     , TreeSitter.Cursor
   Include-dirs:        includes
                      , vendor/tree-sitter/lib/include
                      , vendor/tree-sitter/lib/src

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -7,6 +7,7 @@ import Foreign.Ptr
 import TreeSitter.Node
 
 data Cursor = Cursor
+  deriving (Show)
 
 sizeOfCursor :: Int
 sizeOfCursor = 72

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,3 +1,15 @@
 module TreeSitter.Cursor where
 
+import Foreign.Ptr
+import TreeSitter.Node
+
 data Cursor = Cursor
+
+foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_new_p :: Ptr TSNode -> Ptr Cursor -> IO ()
+foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
+
+foreign import ccall unsafe "src/bridge.c ts_tree_cursor_current_node_p" ts_tree_cursor_current_node_p :: Ptr Cursor -> Ptr TSNode -> IO ()
+
+foreign import ccall unsafe "ts_tree_cursor_goto_parent" ts_tree_cursor_goto_parent :: Ptr Cursor -> IO Bool
+foreign import ccall unsafe "ts_tree_cursor_goto_next_sibling" ts_tree_cursor_goto_next_sibling :: Ptr Cursor -> IO Bool
+foreign import ccall unsafe "ts_tree_cursor_goto_first_child" ts_tree_cursor_goto_first_child :: Ptr Cursor -> IO Bool

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,5 +1,7 @@
 module TreeSitter.Cursor where
 
+import Data.Int
+import Data.Word
 import Foreign.C
 import Foreign.Ptr
 import TreeSitter.Node
@@ -19,3 +21,4 @@ foreign import ccall unsafe "ts_tree_cursor_current_field_id" ts_tree_cursor_cur
 foreign import ccall unsafe "ts_tree_cursor_goto_parent" ts_tree_cursor_goto_parent :: Ptr Cursor -> IO Bool
 foreign import ccall unsafe "ts_tree_cursor_goto_next_sibling" ts_tree_cursor_goto_next_sibling :: Ptr Cursor -> IO Bool
 foreign import ccall unsafe "ts_tree_cursor_goto_first_child" ts_tree_cursor_goto_first_child :: Ptr Cursor -> IO Bool
+foreign import ccall unsafe "ts_tree_cursor_goto_first_child_for_byte" ts_tree_cursor_goto_first_child_for_byte :: Ptr Cursor -> Word32 -> IO Int64

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -12,6 +12,7 @@ import TreeSitter.Node
 data Cursor = Cursor
   deriving (Show)
 
+-- | THe size of a 'Cursor' in bytes. The tests verify that this value is the same as @sizeof(TSTreeCursor)@.
 sizeOfCursor :: Int
 sizeOfCursor = 72
 

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -6,6 +6,9 @@ import Foreign.C
 import Foreign.Ptr
 import TreeSitter.Node
 
+-- | A cursor for traversing a tree.
+--
+--   Note that we do not define 'Eq', 'Ord', or 'Storable' instances, as the underlying @TSTreeCursor@ type is not usefully copyable.
 data Cursor = Cursor
   deriving (Show)
 

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -13,6 +13,7 @@ sizeOfCursor = 72
 
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_new_p :: Ptr TSNode -> Ptr Cursor -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
+foreign import ccall unsafe "src/bridge.c ts_tree_cursor_reset_p" ts_tree_cursor_reset_p :: Ptr Cursor -> Ptr TSNode -> IO ()
 
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_current_node_p" ts_tree_cursor_current_node_p :: Ptr Cursor -> Ptr TSNode -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_current_field_name" ts_tree_cursor_current_field_name :: Ptr Cursor -> IO CString

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,6 +1,5 @@
 module TreeSitter.Cursor where
 
-import Data.Word
 import Foreign.C
 import Foreign.Ptr
 import TreeSitter.Node
@@ -15,7 +14,7 @@ foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr
 
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_current_node_p" ts_tree_cursor_current_node_p :: Ptr Cursor -> Ptr TSNode -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_current_field_name" ts_tree_cursor_current_field_name :: Ptr Cursor -> IO CString
-foreign import ccall unsafe "ts_tree_cursor_current_field_id" ts_tree_cursor_current_field_id :: Ptr Cursor -> IO Word16
+foreign import ccall unsafe "ts_tree_cursor_current_field_id" ts_tree_cursor_current_field_id :: Ptr Cursor -> IO FieldId
 
 foreign import ccall unsafe "ts_tree_cursor_goto_parent" ts_tree_cursor_goto_parent :: Ptr Cursor -> IO Bool
 foreign import ccall unsafe "ts_tree_cursor_goto_next_sibling" ts_tree_cursor_goto_next_sibling :: Ptr Cursor -> IO Bool

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,0 +1,1 @@
+module TreeSitter.Cursor where

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -5,6 +5,9 @@ import TreeSitter.Node
 
 data Cursor = Cursor
 
+sizeOfCursor :: Int
+sizeOfCursor = 72
+
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_new_p :: Ptr TSNode -> Ptr Cursor -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
 

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,5 +1,6 @@
 module TreeSitter.Cursor where
 
+import Foreign.C
 import Foreign.Ptr
 import TreeSitter.Node
 
@@ -12,6 +13,7 @@ foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_n
 foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
 
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_current_node_p" ts_tree_cursor_current_node_p :: Ptr Cursor -> Ptr TSNode -> IO ()
+foreign import ccall unsafe "ts_tree_cursor_current_field_name" ts_tree_cursor_current_field_name :: Ptr Cursor -> IO CString
 
 foreign import ccall unsafe "ts_tree_cursor_goto_parent" ts_tree_cursor_goto_parent :: Ptr Cursor -> IO Bool
 foreign import ccall unsafe "ts_tree_cursor_goto_next_sibling" ts_tree_cursor_goto_next_sibling :: Ptr Cursor -> IO Bool

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,1 +1,3 @@
 module TreeSitter.Cursor where
+
+data Cursor = Cursor

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,5 +1,6 @@
 module TreeSitter.Cursor where
 
+import Data.Word
 import Foreign.C
 import Foreign.Ptr
 import TreeSitter.Node
@@ -14,6 +15,7 @@ foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr
 
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_current_node_p" ts_tree_cursor_current_node_p :: Ptr Cursor -> Ptr TSNode -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_current_field_name" ts_tree_cursor_current_field_name :: Ptr Cursor -> IO CString
+foreign import ccall unsafe "ts_tree_cursor_current_field_id" ts_tree_cursor_current_field_id :: Ptr Cursor -> IO Word16
 
 foreign import ccall unsafe "ts_tree_cursor_goto_parent" ts_tree_cursor_goto_parent :: Ptr Cursor -> IO Bool
 foreign import ccall unsafe "ts_tree_cursor_goto_next_sibling" ts_tree_cursor_goto_next_sibling :: Ptr Cursor -> IO Bool

--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass, InterruptibleFFI, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric, InterruptibleFFI, RankNTypes, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 module TreeSitter.Node
 ( Node(..)

--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE DeriveGeneric, InterruptibleFFI, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric, GeneralizedNewtypeDeriving, InterruptibleFFI, RankNTypes, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 module TreeSitter.Node
 ( Node(..)
 , TSPoint(..)
 , TSNode(..)
+, FieldId(..)
 , ts_node_copy_child_nodes
 ) where
 
@@ -28,6 +29,10 @@ data TSPoint = TSPoint { pointRow :: !Word32, pointColumn :: !Word32 }
 
 data TSNode = TSNode !Word32 !Word32 !Word32 !Word32 !(Ptr ()) !(Ptr ())
   deriving (Show, Eq, Generic)
+
+newtype FieldId = FieldId { getFieldId :: Word16 }
+  deriving (Eq, Ord, Show, Storable)
+
 
 -- | 'Struct' is a strict 'Monad' with automatic alignment & advancing, & inferred type.
 newtype Struct a = Struct { runStruct :: forall b . Ptr b -> IO (a, Ptr a) }

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -75,3 +75,9 @@ void ts_tree_cursor_new_p(TSNode *node, TSTreeCursor *outCursor) {
   assert(outCursor != NULL);
   *outCursor = ts_tree_cursor_new(*node);
 }
+
+void ts_tree_cursor_current_node_p(const TSTreeCursor *cursor, TSNode *outNode) {
+  assert(cursor != NULL);
+  assert(outNode != NULL);
+  *outNode = ts_tree_cursor_current_node(cursor);
+}

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -69,6 +69,10 @@ size_t sizeof_node() {
   return sizeof(Node);
 }
 
+size_t sizeof_tstreecursor() {
+  return sizeof(TSTreeCursor);
+}
+
 
 void ts_tree_cursor_new_p(TSNode *node, TSTreeCursor *outCursor) {
   assert(node != NULL);

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -68,3 +68,10 @@ size_t sizeof_tspoint() {
 size_t sizeof_node() {
   return sizeof(Node);
 }
+
+
+void ts_tree_cursor_new_p(TSNode *node, TSTreeCursor *outCursor) {
+  assert(node != NULL);
+  assert(outCursor != NULL);
+  *outCursor = ts_tree_cursor_new(*node);
+}

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -80,6 +80,12 @@ void ts_tree_cursor_new_p(TSNode *node, TSTreeCursor *outCursor) {
   *outCursor = ts_tree_cursor_new(*node);
 }
 
+void ts_tree_cursor_reset_p(TSTreeCursor *cursor, TSNode *node) {
+  assert(cursor != NULL);
+  assert(node != NULL);
+  ts_tree_cursor_reset(cursor, *node);
+}
+
 void ts_tree_cursor_current_node_p(const TSTreeCursor *cursor, TSNode *outNode) {
   assert(cursor != NULL);
   assert(outNode != NULL);

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@ import Foreign
 import Foreign.C.Types
 import Foreign.Storable
 import Test.Hspec
+import TreeSitter.Cursor
 import TreeSitter.Node
 import TreeSitter.Parser
 
@@ -28,6 +29,10 @@ main = hspec $ do
     it "roundtrips correctly" $
       with (Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8) peek `shouldReturn` Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8
 
+  describe "TSTreeCursor" $ do
+    it "has the same size as its C counterpart" $
+      sizeOfCursor `shouldBe` fromIntegral sizeof_node
+
   describe "Parser" $ do
     it "stores a timeout value" $ do
       parser <- ts_parser_new
@@ -41,3 +46,4 @@ main = hspec $ do
 foreign import ccall unsafe "src/bridge.c sizeof_tsnode" sizeof_tsnode :: CSize
 foreign import ccall unsafe "src/bridge.c sizeof_tspoint" sizeof_tspoint :: CSize
 foreign import ccall unsafe "src/bridge.c sizeof_node" sizeof_node :: CSize
+foreign import ccall unsafe "src/bridge.c sizeof_tstreecursor" sizeof_tstreecursor :: CSize


### PR DESCRIPTION
This PR surfaces (most of) the `ts_tree_cursor*` API to Haskell consumers.

Minor bridging extensions for pointer FFI nonsense included.

🎩 @aymannadeem