### PR TITLE
Import datatypes via the Cursor API

### DIFF
--- a/haskell-tree-sitter.cabal
+++ b/haskell-tree-sitter.cabal
@@ -35,6 +35,7 @@ library
                      , CodeGen.GenerateSyntax
                      , CodeGen.Deserialize
                      --, TreeSitter.Ptr
+                     , TreeSitter.Cursor
   Include-dirs:        includes
                      , vendor/tree-sitter/lib/include
                      , vendor/tree-sitter/lib/src

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,0 +1,15 @@
+module TreeSitter.Cursor where
+
+import Foreign.Ptr
+import TreeSitter.Node
+
+data Cursor = Cursor
+
+foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_new_p :: Ptr TSNode -> Ptr Cursor -> IO ()
+foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
+
+foreign import ccall unsafe "src/bridge.c ts_tree_cursor_current_node_p" ts_tree_cursor_current_node_p :: Ptr Cursor -> Ptr TSNode -> IO ()
+
+foreign import ccall unsafe "ts_tree_cursor_goto_parent" ts_tree_cursor_goto_parent :: Ptr Cursor -> IO Bool
+foreign import ccall unsafe "ts_tree_cursor_goto_next_sibling" ts_tree_cursor_goto_next_sibling :: Ptr Cursor -> IO Bool
+foreign import ccall unsafe "ts_tree_cursor_goto_first_child" ts_tree_cursor_goto_first_child :: Ptr Cursor -> IO Bool

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -5,6 +5,9 @@ import TreeSitter.Node
 
 data Cursor = Cursor
 
+sizeOfCursor :: Int
+sizeOfCursor = 72
+
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_new_p :: Ptr TSNode -> Ptr Cursor -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
 

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -16,9 +16,6 @@ data Cursor = Cursor
 sizeOfCursor :: Int
 sizeOfCursor = 72
 
-sizeOfCursor :: Int
-sizeOfCursor = 72
-
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_new_p :: Ptr TSNode -> Ptr Cursor -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_reset_p" ts_tree_cursor_reset_p :: Ptr Cursor -> Ptr TSNode -> IO ()

--- a/src/TreeSitter/Cursor.hs
+++ b/src/TreeSitter/Cursor.hs
@@ -1,18 +1,33 @@
 module TreeSitter.Cursor where
 
+import Data.Int
+import Data.Word
+import Foreign.C
 import Foreign.Ptr
 import TreeSitter.Node
 
+-- | A cursor for traversing a tree.
+--
+--   Note that we do not define 'Eq', 'Ord', or 'Storable' instances, as the underlying @TSTreeCursor@ type is not usefully copyable.
 data Cursor = Cursor
+  deriving (Show)
+
+-- | THe size of a 'Cursor' in bytes. The tests verify that this value is the same as @sizeof(TSTreeCursor)@.
+sizeOfCursor :: Int
+sizeOfCursor = 72
 
 sizeOfCursor :: Int
 sizeOfCursor = 72
 
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_new_p" ts_tree_cursor_new_p :: Ptr TSNode -> Ptr Cursor -> IO ()
 foreign import ccall unsafe "ts_tree_cursor_delete" ts_tree_cursor_delete :: Ptr Cursor -> IO ()
+foreign import ccall unsafe "src/bridge.c ts_tree_cursor_reset_p" ts_tree_cursor_reset_p :: Ptr Cursor -> Ptr TSNode -> IO ()
 
 foreign import ccall unsafe "src/bridge.c ts_tree_cursor_current_node_p" ts_tree_cursor_current_node_p :: Ptr Cursor -> Ptr TSNode -> IO ()
+foreign import ccall unsafe "ts_tree_cursor_current_field_name" ts_tree_cursor_current_field_name :: Ptr Cursor -> IO CString
+foreign import ccall unsafe "ts_tree_cursor_current_field_id" ts_tree_cursor_current_field_id :: Ptr Cursor -> IO FieldId
 
 foreign import ccall unsafe "ts_tree_cursor_goto_parent" ts_tree_cursor_goto_parent :: Ptr Cursor -> IO Bool
 foreign import ccall unsafe "ts_tree_cursor_goto_next_sibling" ts_tree_cursor_goto_next_sibling :: Ptr Cursor -> IO Bool
 foreign import ccall unsafe "ts_tree_cursor_goto_first_child" ts_tree_cursor_goto_first_child :: Ptr Cursor -> IO Bool
+foreign import ccall unsafe "ts_tree_cursor_goto_first_child_for_byte" ts_tree_cursor_goto_first_child_for_byte :: Ptr Cursor -> Word32 -> IO Int64

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -48,6 +48,13 @@ importByteString parser bytestring =
                 Just <$> runM (runReader bytestring (import' node))
       Exc.bracket acquire release go)
 
+withCursor :: Ptr TSNode -> (Ptr Cursor -> IO a) -> IO a
+withCursor rootPtr action = allocaBytes sizeOfCursor $ \ cursor -> Exc.bracket_
+  (ts_tree_cursor_new_p rootPtr cursor)
+  (ts_tree_cursor_delete cursor)
+  (action cursor)
+
+
 instance (Importing a, Importing b) => Importing (a,b) where
   import' node = do
     [a,b] <- liftIO $ allocaArray 2 $ \ childNodesPtr -> do

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -101,6 +101,13 @@ importSum importA importB cursor = do
   _ <- liftIO $ ts_tree_cursor_goto_parent cursor
   pure e
 
+push :: MonadIO m => Ptr Cursor -> m a -> m a
+push cursor m = do
+  _ <- liftIO $ ts_tree_cursor_goto_first_child cursor
+  a <- m
+  _ <- liftIO $ ts_tree_cursor_goto_parent cursor
+  pure a
+
 
 -- | Return a 'ByteString' that contains a slice of the given 'Source'.
 slice :: Int -> Int -> ByteString -> ByteString

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -57,6 +57,15 @@ instance (Importing a, Importing b) => Importing (a,b) where
     b' <- import' b
     pure (a',b')
 
+importPair :: (Ptr Cursor -> ReaderC ByteString (LiftC IO) a) -> (Ptr Cursor -> ReaderC ByteString (LiftC IO) b) -> Ptr Cursor -> ReaderC ByteString (LiftC IO) (a, b)
+importPair importA importB cursor = do
+  _ <- liftIO $ ts_tree_cursor_goto_first_child cursor
+  a <- importA cursor
+  _ <- liftIO $ ts_tree_cursor_goto_next_sibling cursor
+  b <- importB cursor
+  _ <- liftIO $ ts_tree_cursor_goto_parent cursor
+  pure (a, b)
+
 
 instance Importing Text.Text where
   import' node = do

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -95,11 +95,8 @@ instance (Importing a, Importing b) => Importing (Either a b) where
     Left <$> import' @a childNode <|> Right <$> import' @b childNode
 
 importSum :: (Ptr Cursor -> ReaderC ByteString (LiftC IO) a) -> (Ptr Cursor -> ReaderC ByteString (LiftC IO) b) -> Ptr Cursor -> ReaderC ByteString (LiftC IO) (Either a b)
-importSum importA importB cursor = do
-  _ <- liftIO $ ts_tree_cursor_goto_first_child cursor
-  e <- Left <$> importA cursor <|> Right <$> importB cursor
-  _ <- liftIO $ ts_tree_cursor_goto_parent cursor
-  pure e
+importSum importA importB cursor = push cursor $
+  Left <$> importA cursor <|> Right <$> importB cursor
 
 push :: MonadIO m => Ptr Cursor -> m a -> m a
 push cursor m = do

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -117,7 +117,7 @@ slice start end = take . drop
 
 class Importing type' where
 
-  import' :: Ptr Cursor -> ReaderC ByteString (LiftC IO) type'
+  import' :: (Alternative m, Carrier sig m, Member (Reader ByteString) sig, MonadIO m) => Ptr Cursor -> m type'
 
 newtype MaybeC m a = MaybeC { runMaybeC :: m (Maybe a) }
   deriving (Functor)

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -48,7 +48,7 @@ importByteString parser bytestring =
               else do
                 ts_tree_root_node_p treePtr rootPtr
                 withCursor (castPtr rootPtr) $ \ cursor ->
-                  Just <$> runM (runReader bytestring (import' cursor))
+                  Just <$> runM (runReader cursor (runReader bytestring (import' cursor)))
       Exc.bracket acquire release go)
 
 withCursor :: Ptr TSNode -> (Ptr Cursor -> IO a) -> IO a
@@ -117,7 +117,7 @@ slice start end = take . drop
 
 class Importing type' where
 
-  import' :: (Alternative m, Carrier sig m, Member (Reader ByteString) sig, MonadIO m) => Ptr Cursor -> m type'
+  import' :: (Alternative m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => Ptr Cursor -> m type'
 
 newtype MaybeC m a = MaybeC { runMaybeC :: m (Maybe a) }
   deriving (Functor)

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -90,7 +90,7 @@ push cursor m = do
   _ <- liftIO $ ts_tree_cursor_goto_parent cursor
   pure a
 
-step :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => ReaderC (Ptr Cursor) m ()
+step :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m ()
 step = void $ ask >>= liftIO . ts_tree_cursor_goto_next_sibling
 
 push' :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m a -> m a

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -58,12 +58,10 @@ instance (Importing a, Importing b) => Importing (a,b) where
     pure (a',b')
 
 importPair :: (Ptr Cursor -> ReaderC ByteString (LiftC IO) a) -> (Ptr Cursor -> ReaderC ByteString (LiftC IO) b) -> Ptr Cursor -> ReaderC ByteString (LiftC IO) (a, b)
-importPair importA importB cursor = do
-  _ <- liftIO $ ts_tree_cursor_goto_first_child cursor
+importPair importA importB cursor = push cursor $ do
   a <- importA cursor
   _ <- liftIO $ ts_tree_cursor_goto_next_sibling cursor
   b <- importB cursor
-  _ <- liftIO $ ts_tree_cursor_goto_parent cursor
   pure (a, b)
 
 

--- a/src/TreeSitter/Importing.hs
+++ b/src/TreeSitter/Importing.hs
@@ -94,6 +94,13 @@ instance (Importing a, Importing b) => Importing (Either a b) where
       peekArray 1 childNodesPtr
     Left <$> import' @a childNode <|> Right <$> import' @b childNode
 
+importSum :: (Ptr Cursor -> ReaderC ByteString (LiftC IO) a) -> (Ptr Cursor -> ReaderC ByteString (LiftC IO) b) -> Ptr Cursor -> ReaderC ByteString (LiftC IO) (Either a b)
+importSum importA importB cursor = do
+  _ <- liftIO $ ts_tree_cursor_goto_first_child cursor
+  e <- Left <$> importA cursor <|> Right <$> importB cursor
+  _ <- liftIO $ ts_tree_cursor_goto_parent cursor
+  pure e
+
 
 -- | Return a 'ByteString' that contains a slice of the given 'Source'.
 slice :: Int -> Int -> ByteString -> ByteString

--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass, InterruptibleFFI, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric, GeneralizedNewtypeDeriving, InterruptibleFFI, RankNTypes, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 module TreeSitter.Node
 ( Node(..)
 , TSPoint(..)
 , TSNode(..)
+, FieldId(..)
 , ts_node_copy_child_nodes
 , ts_node_poke_p
 ) where
@@ -29,6 +30,10 @@ data TSPoint = TSPoint { pointRow :: !Word32, pointColumn :: !Word32 }
 
 data TSNode = TSNode !Word32 !Word32 !Word32 !Word32 !(Ptr ()) !(Ptr ())
   deriving (Show, Eq, Generic)
+
+newtype FieldId = FieldId { getFieldId :: Word16 }
+  deriving (Eq, Ord, Show, Storable)
+
 
 -- | 'Struct' is a strict 'Monad' with automatic alignment & advancing, & inferred type.
 newtype Struct a = Struct { runStruct :: forall b . Ptr b -> IO (a, Ptr a) }

--- a/src/TreeSitter/Node.hs
+++ b/src/TreeSitter/Node.hs
@@ -5,6 +5,7 @@ module TreeSitter.Node
 , TSPoint(..)
 , TSNode(..)
 , ts_node_copy_child_nodes
+, ts_node_poke_p
 ) where
 
 import Foreign
@@ -128,3 +129,4 @@ instance Monad Struct where
 
 
 foreign import ccall interruptible "src/bridge.c ts_node_copy_child_nodes" ts_node_copy_child_nodes :: Ptr TSNode -> Ptr Node -> IO ()
+foreign import ccall unsafe "src/bridge.c ts_node_poke_p" ts_node_poke_p :: Ptr TSNode -> Ptr Node -> IO ()

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -85,6 +85,12 @@ void ts_tree_cursor_new_p(TSNode *node, TSTreeCursor *outCursor) {
   *outCursor = ts_tree_cursor_new(*node);
 }
 
+void ts_tree_cursor_reset_p(TSTreeCursor *cursor, TSNode *node) {
+  assert(cursor != NULL);
+  assert(node != NULL);
+  ts_tree_cursor_reset(cursor, *node);
+}
+
 void ts_tree_cursor_current_node_p(const TSTreeCursor *cursor, TSNode *outNode) {
   assert(cursor != NULL);
   assert(outNode != NULL);

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -68,3 +68,16 @@ size_t sizeof_tspoint() {
 size_t sizeof_node() {
   return sizeof(Node);
 }
+
+
+void ts_tree_cursor_new_p(TSNode *node, TSTreeCursor *outCursor) {
+  assert(node != NULL);
+  assert(outCursor != NULL);
+  *outCursor = ts_tree_cursor_new(*node);
+}
+
+void ts_tree_cursor_current_node_p(const TSTreeCursor *cursor, TSNode *outNode) {
+  assert(cursor != NULL);
+  assert(outNode != NULL);
+  *outNode = ts_tree_cursor_current_node(cursor);
+}

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -74,6 +74,10 @@ size_t sizeof_node() {
   return sizeof(Node);
 }
 
+size_t sizeof_tstreecursor() {
+  return sizeof(TSTreeCursor);
+}
+
 
 void ts_tree_cursor_new_p(TSNode *node, TSTreeCursor *outCursor) {
   assert(node != NULL);

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -33,6 +33,11 @@ static inline void ts_node_poke(TSNode node, Node *out) {
   out->childCount = ts_node_child_count(node);
 }
 
+void ts_node_poke_p(TSNode *node, Node *out) {
+  assert(node != NULL);
+  ts_node_poke(*node, out);
+}
+
 void ts_tree_root_node_p(TSTree *tree, Node *outNode) {
   assert(tree != NULL);
   assert(outNode != NULL);

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@ import Foreign
 import Foreign.C.Types
 import Foreign.Storable
 import Test.Hspec
+import TreeSitter.Cursor
 import TreeSitter.Node
 import TreeSitter.Parser
 
@@ -28,6 +29,10 @@ main = hspec $ do
     it "roundtrips correctly" $
       with (Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8) peek `shouldReturn` Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8
 
+  describe "TSTreeCursor" $ do
+    it "has the same size as its C counterpart" $
+      sizeOfCursor `shouldBe` fromIntegral sizeof_node
+
   describe "Parser" $ do
     it "stores a timeout value" $ do
       parser <- ts_parser_new
@@ -41,3 +46,4 @@ main = hspec $ do
 foreign import ccall unsafe "src/bridge.c sizeof_tsnode" sizeof_tsnode :: CSize
 foreign import ccall unsafe "src/bridge.c sizeof_tspoint" sizeof_tspoint :: CSize
 foreign import ccall unsafe "src/bridge.c sizeof_node" sizeof_node :: CSize
+foreign import ccall unsafe "src/bridge.c sizeof_tstreecursor" sizeof_tstreecursor :: CSize


### PR DESCRIPTION
- [ ] Depends on #87.
- [x] Migrates the `Importing` interface to use a `Reader` effect holding a `Ptr Cursor` which we mutate.

🎩 @aymannadeem

cc @maxbrunsfeld