### PR TITLE
Build all language subprojects in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ install:
 - cabal new-build --only-dependencies
 
 script:
-- cabal new-build
+- cabal new-build all
 - cabal new-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ before_install:
 install:
 - cabal new-update
 - cabal new-configure --enable-benchmarks --enable-tests --write-ghc-environment-files=always
-- cabal new-build --only-dependencies
+- cabal new-build -j --ghc-options="-O0" --only-dependencies
 
 script:
-- cabal new-build all
+- cabal new-build -j --ghc-options="-O0" all
 - cabal new-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ install:
 
 script:
 - cabal new-build -j --ghc-options="-O0" all
-- cabal new-test
+- cabal new-test -j --ghc-options="-O0"

--- a/languages/python/TreeSitter/Python.hs
+++ b/languages/python/TreeSitter/Python.hs
@@ -18,5 +18,5 @@ $(do
   currentFilename <- loc_filename <$> location
   pwd             <- runIO getCurrentDirectory
   let invocationRelativePath = takeDirectory (pwd </> currentFilename) </> "../vendor/tree-sitter-python/src/node-types.json"
-  input <- liftIO (eitherDecodeFileStrict' invocationRelativePath)
+  input <- runIO (eitherDecodeFileStrict' invocationRelativePath)
   either fail (traverse datatypeForConstructors) input)

--- a/languages/python/tree-sitter-python.cabal
+++ b/languages/python/tree-sitter-python.cabal
@@ -13,8 +13,11 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     TreeSitter.Python
-                     , TreeSitter.CodeGen
   build-depends:       base >= 4.7 && < 5
+                     , directory >= 1.3.0.2 && < 1.4
+                     , filepath >= 1.4.1.2 && < 1.5
+                     , template-haskell >= 2.12.0.0 && < 2.15.0.0
+                     , aeson
                      , haskell-tree-sitter
   default-language:    Haskell2010
   Include-dirs:        vendor/tree-sitter-python/src


### PR DESCRIPTION
We weren’t building all the targets, which means that `tree-sitter-python` compilation has been broken on master for some time. This fixes it.