### PR TITLE
Check for incompatible parser versions

### DIFF
--- a/src/TreeSitter/Parser.hs
+++ b/src/TreeSitter/Parser.hs
@@ -12,7 +12,7 @@ foreign import ccall safe "ts_parser_new" ts_parser_new :: IO (Ptr Parser)
 foreign import ccall safe "ts_parser_halt_on_error" ts_parser_halt_on_error :: Ptr Parser -> CBool -> IO ()
 foreign import ccall safe "ts_parser_parse_string" ts_parser_parse_string :: Ptr Parser -> Ptr Tree -> CString -> Int -> IO (Ptr Tree)
 foreign import ccall safe "ts_parser_delete" ts_parser_delete :: Ptr Parser -> IO ()
-foreign import ccall safe "ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO ()
+foreign import ccall safe "ts_parser_set_language" ts_parser_set_language :: Ptr Parser -> Ptr Language -> IO Bool
 foreign import ccall safe "ts_parser_timeout_micros" ts_parser_timeout_micros :: Ptr Parser -> IO Word64
 foreign import ccall safe "ts_parser_set_timeout_micros" ts_parser_set_timeout_micros :: Ptr Parser -> Word64 -> IO ()
 


### PR DESCRIPTION
Fixes #2, albeit in the boring-est way possible (just returning a `Bool`, offering no support to actually indicate which versions we’re dealing with).

- [x] Depends on #116.