### PR TITLE
Try <> instead of "" for headers found in include-dirs

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -1,4 +1,4 @@
-#include "tree_sitter/api.h"
+#include <tree_sitter/api.h>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Hopefully this should deal with https://github.com/github/semantic/issues/96.