### PR TITLE
Only test on GHC 8.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,8 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.6.2"
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.4"
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.2"
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.4"
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.4], sources: [hvr-ghc]}}
 
 before_install:
 - mkdir -p $HOME/.local/bin

--- a/src/CodeGen/GenerateSyntax.hs
+++ b/src/CodeGen/GenerateSyntax.hs
@@ -12,7 +12,6 @@ module CodeGen.GenerateSyntax
 ) where
 
 import Data.Char
-import Data.Semigroup
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax as TH
 import CodeGen.Deserialize (MkDatatype (..), MkDatatypeName (..), MkField (..), MkRequired (..), MkType (..), MkNamed (..), MkMultiple (..))


### PR DESCRIPTION
Targeting newer GHCs makes our lives easier (and is fine because the
8.6-only `semantic` is the only app depending on this). The fewer
carbon emissions, the better, IMO.

Also fixes a stray import that 8.2 was complaining about.