### PR TITLE
Remove per-language .stack.yaml files and bump LTS version.

### DIFF
--- a/languages/go/stack.yaml
+++ b/languages/go/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: nightly-2017-09-10

--- a/languages/haskell/stack.yaml
+++ b/languages/haskell/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: lts-12.17

--- a/languages/java/stack.yaml
+++ b/languages/java/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: nightly-2017-09-10

--- a/languages/json/stack.yaml
+++ b/languages/json/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: nightly-2017-09-10

--- a/languages/php/stack.yaml
+++ b/languages/php/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: nightly-2017-09-10

--- a/languages/python/stack.yaml
+++ b/languages/python/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: nightly-2017-09-10

--- a/languages/ruby/stack.yaml
+++ b/languages/ruby/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: nightly-2017-09-10

--- a/languages/typescript/stack.yaml
+++ b/languages/typescript/stack.yaml
@@ -1,8 +1,0 @@
-flags: {}
-extra-package-dbs: []
-packages:
-- '.'
-- '../../'
-extra-deps:
-- c-storable-deriving-0.1.3
-resolver: nightly-2017-09-10

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,6 @@ packages:
   extra-dep: true
 - location: languages/haskell
   extra-dep: true
-resolver: lts-12.17
+resolver: lts-13.13
 extra-deps:
   - fused-effects-0.4.0.0


### PR DESCRIPTION
We're deprecating `stack` as the environment of choice for hacking on
the Semantic ecosystem, but I don't want to blow up @aymannadeem's
setup yet, so this doesn't yet remove the main stack.yaml. It does,
however, remove all the other nested stack files, and works with #121.

Fixes #109.