### PR TITLE
Ensure we get the parser header file.

### DIFF
--- a/languages/go/tree-sitter-go.cabal
+++ b/languages/go/tree-sitter-go.cabal
@@ -25,7 +25,8 @@ library tree-sitter-go-internal
   build-depends:       base                 >= 4.12 && < 5
                      , tree-sitter ^>= 0.1.0.0
   default-language:    Haskell2010
-  Include-dirs:        vendor/tree-sitter-go/src
+  include-dirs:        vendor/tree-sitter-go/src
+  install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-go/src/parser.c
 
 source-repository head


### PR DESCRIPTION
I’m not sure if this is necessary, but it might be.