### PR TITLE
Refactor: give mapOperator a more descriptive name

### DIFF
--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -9,8 +9,10 @@ module CodeGen.GenerateSyntax
 ( syntaxDatatype
 , removeUnderscore
 , initUpper
-, mapOperator
 , astDeclarationsForLanguage
+-- * Internal functions exposed for testing
+, escapeOperatorPunctuation
+
 ) where
 
 import Data.Char
@@ -144,7 +146,7 @@ toType xs = foldr1 combine $ map convertToQType xs
 
 -- | Convert snake_case string to CamelCase String
 toCamelCase :: String -> String
-toCamelCase = initUpper . mapOperator . removeUnderscore
+toCamelCase = initUpper . escapeOperatorPunctuation . removeUnderscore
 
 clashingNames :: HashSet String
 clashingNames = HashSet.fromList ["type", "module", "data"]
@@ -175,13 +177,10 @@ removeUnderscore = foldr appender ""
         appender '_' cs = initUpper cs
         appender c cs = c : cs
 
--- Helper function to map operators to valid Haskell identifier
-mapOperator :: String -> String
-mapOperator = concatMap toDescription
-
--- Helper function to map operator characters to strings
-toDescription :: Char -> String
-toDescription = \case
+-- Ensures that we generate valid Haskell identifiers from
+-- the literal characters used for infix operators and punctuation.
+escapeOperatorPunctuation :: String -> String
+escapeOperatorPunctuation = concatMap $ \case
   '{'  -> "LBrace"
   '}'  -> "RBrace"
   '('  -> "LParen"
@@ -217,5 +216,5 @@ toDescription = \case
   '\n' -> "LF"
   '\r' -> "CR"
   other
-    | isControl other -> mapOperator (show other)
+    | isControl other -> escapeOperatorPunctuation (show other)
     | otherwise       -> [other]

--- a/tree-sitter/test-codegen/test-codegen.hs
+++ b/tree-sitter/test-codegen/test-codegen.hs
@@ -39,10 +39,10 @@ prop_initUpper = property $ do
   (y:ys) <- pure $ initUpper (x:xs)
   when (isLower x) (assert (isUpper y))
 
-prop_mapOperator :: Property
-prop_mapOperator = property $ do
+prop_escapePunct :: Property
+prop_escapePunct = property $ do
   xs <- forAll $ Gen.string (Range.constant 1 5) (Gen.filter p Gen.ascii)
-  traverse_ (assert . isAlphaNum) (mapOperator xs)
+  traverse_ (assert . isAlphaNum) (escapeOperatorPunctuation xs)
   where p = not . (\c -> isSpace c || c == '_' )
 
 main :: IO ()


### PR DESCRIPTION
Since both "map" and "operator" are pretty overloaded words in
Haskell, I figured we could pick a more specific name as to this
function. I also pulled out its helper into a lambda-case, since it
wasn't used anywhere else and didn't entail big churn in the diff.