### PR TITLE
Refactor: add name field to MkField and remove tuples

### DIFF
--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-python
-version:             0.1.1.0
+version:             0.1.0.1
 synopsis:            Tree-sitter grammar/parser for Python
 description:         This package provides a parser for Python suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-python
-version:             0.1.0.1
+version:             0.1.1.0
 synopsis:            Tree-sitter grammar/parser for Python
 description:         This package provides a parser for Python suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -31,7 +31,7 @@ data MkDatatype
   | ProductType
   { datatypeName   :: MkDatatypeName
   , isName         :: MkNamed
-  , datatypeFields :: NonEmpty (String, MkField)
+  , datatypeFields :: NonEmpty MkField
   }
   | LeafType
   { datatypeName :: MkDatatypeName
@@ -55,17 +55,18 @@ instance FromJSON MkDatatype where
       Just subtypes   -> pure (SumType type' named subtypes)
 
 -- | Transforms list of key-value pairs to a Parser
-parseKVPairs :: NonEmpty (Text, Value) -> Parser (NonEmpty (String, MkField))
+parseKVPairs :: NonEmpty (Text, Value) -> Parser (NonEmpty MkField)
 parseKVPairs = traverse go
-  where go :: (Text, Value) -> Parser (String, MkField)
+  where go :: (Text, Value) -> Parser MkField
         go (t,v) = do
           v' <- parseJSON v
-          pure (unpack t, v')
+          pure $ v' { fieldName = Just (unpack t) }
 
 data MkField = MkField
   { fieldRequired :: MkRequired
-  , fieldTypes     :: [MkType]
+  , fieldTypes    :: [MkType]
   , fieldMultiple :: MkMultiple
+  , fieldName     :: Maybe String
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
 

--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -62,7 +62,7 @@ parseKVPairs = traverse go
           v' <- parseJSON v
           pure $ v' { fieldName = Just (unpack t) }
 
-data Field = Field
+data Field = MkField
   { fieldRequired :: Required
   , fieldTypes    :: [Type]
   , fieldMultiple :: Multiple

--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -120,7 +120,7 @@ toBangType (MkType (DatatypeName n) named) = do
 -- | For product types, examine the field's contents required for generating
 --   Haskell code with records in the case of ProductTypes
 toVarBangType :: Field -> Q VarBangType
-toVarBangType (Field required fieldType multiplicity (Just name)) = do
+toVarBangType (MkField required fieldType multiplicity (Just name)) = do
   ty' <- ty
   let newName = mkName . addTickIfNecessary . removeUnderscore $ name
   pure (newName, Bang TH.NoSourceUnpackedness TH.NoSourceStrictness, ty')
@@ -130,7 +130,7 @@ toVarBangType (Field required fieldType multiplicity (Just name)) = do
         mult = case multiplicity of
           Multiple -> [t|[$(toType fieldType)]|]
           Single   -> toType fieldType
-toVarBangType (Field _ _ _ Nothing) =
+toVarBangType (MkField _ _ _ Nothing) =
   fail "toVarBangType: invariant violated (MkField did not contain a name)"
 
 -- | Convert field types to Q types


### PR DESCRIPTION
Because we generally prefer one single-constructor data type rather
than a type over a tuple, I've changed away from `(String, MkField)`
values and added a corresponding `String` inside `MkField` instead.