### PR TITLE
Remove `Mk` prefixes on datatypes

### DIFF
--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -6,7 +6,7 @@
 module CodeGen.Deserialize
 ( Datatype (..)
 , Field (..)
-, MkRequired (..)
+, Required (..)
 , MkType (..)
 , DatatypeName (..)
 , MkNamed (..)
@@ -63,7 +63,7 @@ parseKVPairs = traverse go
           pure (unpack t, v')
 
 data Field = MkField
-  { fieldRequired :: MkRequired
+  { fieldRequired :: Required
   , fieldTypes     :: [MkType]
   , fieldMultiple :: MkMultiple
   }
@@ -72,10 +72,10 @@ data Field = MkField
 instance FromJSON Field where
   parseJSON = genericParseJSON customOptions
 
-data MkRequired = Optional | Required
+data Required = Optional | Required
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
-instance FromJSON MkRequired where
+instance FromJSON Required where
   parseJSON = withBool "Required" (\p -> pure (if p then Required else Optional))
 
 data MkType = MkType

--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -9,8 +9,8 @@ module CodeGen.Deserialize
 , Required (..)
 , Type (..)
 , DatatypeName (..)
-, MkNamed (..)
-, MkMultiple (..)
+, Named (..)
+, Multiple (..)
 ) where
 
 import Data.Aeson as Aeson
@@ -25,17 +25,17 @@ import qualified Data.HashMap.Strict as HM
 data Datatype
   = SumType
   { datatypeName :: DatatypeName
-  , isName :: MkNamed
+  , isName :: Named
   , datatypeSubtypes :: [Type]
   }
   | ProductType
   { datatypeName   :: DatatypeName
-  , isName         :: MkNamed
+  , isName         :: Named
   , datatypeFields :: NonEmpty (String, Field)
   }
   | LeafType
   { datatypeName :: DatatypeName
-  , isName       :: MkNamed
+  , isName       :: Named
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
@@ -65,7 +65,7 @@ parseKVPairs = traverse go
 data Field = MkField
   { fieldRequired :: Required
   , fieldTypes     :: [Type]
-  , fieldMultiple :: MkMultiple
+  , fieldMultiple :: Multiple
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
@@ -80,7 +80,7 @@ instance FromJSON Required where
 
 data Type = MkType
   { fieldType :: DatatypeName
-  , isNamed :: MkNamed
+  , isNamed :: Named
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
@@ -91,16 +91,16 @@ newtype DatatypeName = DatatypeName { getDatatypeName :: String }
   deriving (Eq, Ord, Show, Generic)
   deriving newtype (FromJSON, ToJSON)
 
-data MkNamed = Anonymous | Named
+data Named = Anonymous | Named
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
-instance FromJSON MkNamed where
+instance FromJSON Named where
   parseJSON = withBool "Named" (\p -> pure (if p then Named else Anonymous))
 
-data MkMultiple = Single | Multiple
+data Multiple = Single | Multiple
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
-instance FromJSON MkMultiple where
+instance FromJSON Multiple where
   parseJSON = withBool "Multiple" (\p -> pure (if p then Multiple else Single))
 
 customOptions :: Aeson.Options

--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -4,11 +4,11 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
 module CodeGen.Deserialize
-( MkDatatype (..)
+( Datatype (..)
 , MkField (..)
 , MkRequired (..)
 , MkType (..)
-, MkDatatypeName (..)
+, DatatypeName (..)
 , MkNamed (..)
 , MkMultiple (..)
 ) where
@@ -22,25 +22,25 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.HashMap.Strict as HM
 
 -- Types to deserialize into:
-data MkDatatype
+data Datatype
   = SumType
-  { datatypeName :: MkDatatypeName
+  { datatypeName :: DatatypeName
   , isName :: MkNamed
   , datatypeSubtypes :: [MkType]
   }
   | ProductType
-  { datatypeName   :: MkDatatypeName
+  { datatypeName   :: DatatypeName
   , isName         :: MkNamed
   , datatypeFields :: NonEmpty (String, MkField)
   }
   | LeafType
-  { datatypeName :: MkDatatypeName
+  { datatypeName :: DatatypeName
   , isName       :: MkNamed
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
-instance FromJSON MkDatatype where
-  parseJSON = withObject "MkDatatype" $ \v -> do
+instance FromJSON Datatype where
+  parseJSON = withObject "Datatype" $ \v -> do
     type' <- v .: "type"
     named <- v .: "named"
     subtypes <- v .:? "subtypes"
@@ -79,7 +79,7 @@ instance FromJSON MkRequired where
   parseJSON = withBool "Required" (\p -> pure (if p then Required else Optional))
 
 data MkType = MkType
-  { fieldType :: MkDatatypeName
+  { fieldType :: DatatypeName
   , isNamed :: MkNamed
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
@@ -87,7 +87,7 @@ data MkType = MkType
 instance FromJSON MkType where
   parseJSON = genericParseJSON customOptions
 
-newtype MkDatatypeName = DatatypeName { getDatatypeName :: String }
+newtype DatatypeName = DatatypeName { getDatatypeName :: String }
   deriving (Eq, Ord, Show, Generic)
   deriving newtype (FromJSON, ToJSON)
 

--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module CodeGen.Deserialize
 ( Datatype (..)
-, MkField (..)
+, Field (..)
 , MkRequired (..)
 , MkType (..)
 , DatatypeName (..)
@@ -31,7 +31,7 @@ data Datatype
   | ProductType
   { datatypeName   :: DatatypeName
   , isName         :: MkNamed
-  , datatypeFields :: NonEmpty (String, MkField)
+  , datatypeFields :: NonEmpty (String, Field)
   }
   | LeafType
   { datatypeName :: DatatypeName
@@ -55,21 +55,21 @@ instance FromJSON Datatype where
       Just subtypes   -> pure (SumType type' named subtypes)
 
 -- | Transforms list of key-value pairs to a Parser
-parseKVPairs :: NonEmpty (Text, Value) -> Parser (NonEmpty (String, MkField))
+parseKVPairs :: NonEmpty (Text, Value) -> Parser (NonEmpty (String, Field))
 parseKVPairs = traverse go
-  where go :: (Text, Value) -> Parser (String, MkField)
+  where go :: (Text, Value) -> Parser (String, Field)
         go (t,v) = do
           v' <- parseJSON v
           pure (unpack t, v')
 
-data MkField = MkField
+data Field = MkField
   { fieldRequired :: MkRequired
   , fieldTypes     :: [MkType]
   , fieldMultiple :: MkMultiple
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
-instance FromJSON MkField where
+instance FromJSON Field where
   parseJSON = genericParseJSON customOptions
 
 data MkRequired = Optional | Required

--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -7,7 +7,7 @@ module CodeGen.Deserialize
 ( Datatype (..)
 , Field (..)
 , Required (..)
-, MkType (..)
+, Type (..)
 , DatatypeName (..)
 , MkNamed (..)
 , MkMultiple (..)
@@ -26,7 +26,7 @@ data Datatype
   = SumType
   { datatypeName :: DatatypeName
   , isName :: MkNamed
-  , datatypeSubtypes :: [MkType]
+  , datatypeSubtypes :: [Type]
   }
   | ProductType
   { datatypeName   :: DatatypeName
@@ -64,7 +64,7 @@ parseKVPairs = traverse go
 
 data Field = MkField
   { fieldRequired :: Required
-  , fieldTypes     :: [MkType]
+  , fieldTypes     :: [Type]
   , fieldMultiple :: MkMultiple
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
@@ -78,13 +78,13 @@ data Required = Optional | Required
 instance FromJSON Required where
   parseJSON = withBool "Required" (\p -> pure (if p then Required else Optional))
 
-data MkType = MkType
+data Type = MkType
   { fieldType :: DatatypeName
   , isNamed :: MkNamed
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)
 
-instance FromJSON MkType where
+instance FromJSON Type where
   parseJSON = genericParseJSON customOptions
 
 newtype DatatypeName = DatatypeName { getDatatypeName :: String }

--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -19,7 +19,7 @@ import Data.Char
 import Language.Haskell.TH
 import Data.HashSet (HashSet)
 import Language.Haskell.TH.Syntax as TH
-import CodeGen.Deserialize (Datatype (..), DatatypeName (..), MkField (..), MkRequired (..), MkType (..), MkNamed (..), MkMultiple (..))
+import CodeGen.Deserialize (Datatype (..), DatatypeName (..), Field (..), MkRequired (..), MkType (..), MkNamed (..), MkMultiple (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Foldable
 import Data.Text (Text)
@@ -95,7 +95,7 @@ toSumCon :: String -> MkType -> Q Con
 toSumCon str (MkType (DatatypeName n) named) = NormalC (toName named (n ++ str)) <$> traverse toBangType [MkType (DatatypeName n) named]
 
 -- | Build Q Constructor for product types (nodes with fields)
-toConProduct :: String -> NonEmpty (String, MkField) -> Q Con
+toConProduct :: String -> NonEmpty (String, Field) -> Q Con
 toConProduct constructorName fields = RecC (toName Named constructorName) <$> fieldList
   where fieldList = toList <$> traverse (uncurry toVarBangType) fields
 
@@ -119,7 +119,7 @@ toBangType (MkType (DatatypeName n) named) = do
 
 -- | For product types, examine the field's contents required for generating
 --   Haskell code with records in the case of ProductTypes
-toVarBangType :: String -> MkField -> Q VarBangType
+toVarBangType :: String -> Field -> Q VarBangType
 toVarBangType name (MkField required fieldType multiplicity) = do
   ty' <- ty
   let newName = mkName . addTickIfNecessary . removeUnderscore $ name

--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -19,7 +19,7 @@ import Data.Char
 import Language.Haskell.TH
 import Data.HashSet (HashSet)
 import Language.Haskell.TH.Syntax as TH
-import CodeGen.Deserialize (MkDatatype (..), MkDatatypeName (..), MkField (..), MkRequired (..), MkType (..), MkNamed (..), MkMultiple (..))
+import CodeGen.Deserialize (Datatype (..), DatatypeName (..), MkField (..), MkRequired (..), MkType (..), MkNamed (..), MkMultiple (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Foldable
 import Data.Text (Text)
@@ -48,7 +48,7 @@ astDeclarationsForLanguage language filePath = do
 
 
 -- Auto-generate Haskell datatypes for sums, products and leaf types
-syntaxDatatype :: Ptr TS.Language -> MkDatatype -> Q [Dec]
+syntaxDatatype :: Ptr TS.Language -> Datatype -> Q [Dec]
 syntaxDatatype language datatype = case datatype of
   SumType (DatatypeName datatypeName) _ subtypes -> do
     cons <- traverse (toSumCon datatypeName) subtypes
@@ -100,7 +100,7 @@ toConProduct constructorName fields = RecC (toName Named constructorName) <$> fi
   where fieldList = toList <$> traverse (uncurry toVarBangType) fields
 
 -- | Build Q Constructor for leaf types (nodes with no fields or subtypes)
-toConLeaf :: MkNamed -> MkDatatypeName -> Q Con
+toConLeaf :: MkNamed -> DatatypeName -> Q Con
 toConLeaf Anonymous (DatatypeName name) = pure (NormalC (toName Anonymous name) [])
 toConLeaf named (DatatypeName name) = RecC (toName named name) <$> leafRecords
   where leafRecords = pure <$> toLeafVarBangTypes

--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -19,7 +19,7 @@ import Data.Char
 import Language.Haskell.TH
 import Data.HashSet (HashSet)
 import Language.Haskell.TH.Syntax as TH
-import CodeGen.Deserialize (Datatype (..), DatatypeName (..), Field (..), MkRequired (..), MkType (..), MkNamed (..), MkMultiple (..))
+import CodeGen.Deserialize (Datatype (..), DatatypeName (..), Field (..), Required (..), MkType (..), MkNamed (..), MkMultiple (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Foldable
 import Data.Text (Text)

--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -19,7 +19,7 @@ import Data.Char
 import Language.Haskell.TH
 import Data.HashSet (HashSet)
 import Language.Haskell.TH.Syntax as TH
-import CodeGen.Deserialize (Datatype (..), DatatypeName (..), Field (..), Required (..), Type (..), MkNamed (..), MkMultiple (..))
+import CodeGen.Deserialize (Datatype (..), DatatypeName (..), Field (..), Required (..), Type (..), Named (..), Multiple (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Foldable
 import Data.Text (Text)
@@ -100,7 +100,7 @@ toConProduct constructorName fields = RecC (toName Named constructorName) <$> fi
   where fieldList = toList <$> traverse (uncurry toVarBangType) fields
 
 -- | Build Q Constructor for leaf types (nodes with no fields or subtypes)
-toConLeaf :: MkNamed -> DatatypeName -> Q Con
+toConLeaf :: Named -> DatatypeName -> Q Con
 toConLeaf Anonymous (DatatypeName name) = pure (NormalC (toName Anonymous name) [])
 toConLeaf named (DatatypeName name) = RecC (toName named name) <$> leafRecords
   where leafRecords = pure <$> toLeafVarBangTypes
@@ -152,7 +152,7 @@ addTickIfNecessary s
   | otherwise                        = s
 
 -- | Prepend "Anonymous" to named node when false, otherwise use regular toName
-toName :: MkNamed -> String -> Name
+toName :: Named -> String -> Name
 toName named str = mkName $ addTickIfNecessary $ case named of
   Anonymous -> "Anonymous" <> toCamelCase str
   Named -> toCamelCase str


### PR DESCRIPTION
Fixes #106

Removing the `Mk` prefixes I included for the datatypes in our Deserialize module. This was originally intended to disambiguate the datatypes but is no longer relevant.