### PR TITLE
Fix constructor name for CodeGen.Deserialize.Type.

### DIFF
--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -79,7 +79,7 @@ data Required = Optional | Required
 instance FromJSON Required where
   parseJSON = withBool "Required" (\p -> pure (if p then Required else Optional))
 
-data Type = MkType
+data Type = Type
   { fieldType :: DatatypeName
   , isNamed :: Named
   }


### PR DESCRIPTION
We ditched the Mk prefixes on constructors altogether, so let's ditch
this here as well.

- [ ] Depends on #156.