### PR TITLE
Refactor: rename and simplify toType.

### DIFF
--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -64,7 +64,7 @@ parseKVPairs = traverse go
 
 data Field = MkField
   { fieldRequired :: Required
-  , fieldTypes     :: [Type]
+  , fieldTypes    :: NonEmpty Type
   , fieldMultiple :: Multiple
   }
   deriving (Eq, Ord, Show, Generic, ToJSON)


### PR DESCRIPTION
There are a lot of functions that begin with `to`, and I'm having
trouble keeping them straight. This patch helps address that by
renaming `toType` to `fieldTypesToNestedEither`, which is much more
specific about its inputs and outputs.

I also removed an error case by switching `MkField` to contain a
`NonEmpty Type` instead of a `[Type]`, and simplified the call to
`fieldTypesToNestedEither` in `toVarBangType`.