### PR TITLE
Refactor: rename toConProduct

### DIFF
--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -55,7 +55,7 @@ syntaxDatatype language datatype = case datatype of
     result <- symbolMatchingInstanceForSums language name subtypes
     pure $ generatedDatatype name cons:result
   ProductType (DatatypeName datatypeName) _ fields -> do
-    con <- toConProduct datatypeName fields
+    con <- ctorForProductType datatypeName fields
     result <- symbolMatchingInstance language name datatypeName
     pure $ generatedDatatype name [con]:result
   LeafType (DatatypeName datatypeName) named -> do
@@ -95,9 +95,16 @@ toSumCon :: String -> CodeGen.Deserialize.Type -> Q Con
 toSumCon str (MkType (DatatypeName n) named) = NormalC (toName named (n ++ str)) <$> traverse toBangType [MkType (DatatypeName n) named]
 
 -- | Build Q Constructor for product types (nodes with fields)
-toConProduct :: String -> NonEmpty (String, Field) -> Q Con
-toConProduct constructorName fields = RecC (toName Named constructorName) <$> fieldList
-  where fieldList = toList <$> traverse (uncurry toVarBangType) fields
+ctorForProductType :: String -> NonEmpty (String, Field) -> Q Con
+ctorForProductType constructorName fields = recC (toName Named constructorName) fieldList where
+  fieldList = toList $ fmap (uncurry toVarBangType) fields
+  toVarBangType name (MkField required fieldTypes _) =
+    let fieldName = mkName . addTickIfNecessary . removeUnderscore $ name
+        strictness = TH.bang noSourceUnpackedness noSourceStrictness
+        contents = if required == Optional then conT ''Maybe `appT` choices else choices
+        choices = fieldTypesToNestedEither fieldTypes
+    in TH.varBangType fieldName (TH.bangType strictness contents)
+
 
 -- | Build Q Constructor for leaf types (nodes with no fields or subtypes)
 ctorForLeafType :: Named -> DatatypeName -> Q Con
@@ -111,18 +118,6 @@ toBangType :: CodeGen.Deserialize.Type -> Q BangType
 toBangType (MkType (DatatypeName n) named) = do
   bangSubtypes <- conT (toName named n)
   pure (Bang TH.NoSourceUnpackedness TH.NoSourceStrictness, bangSubtypes)
-
--- | For product types, examine the field's contents required for generating
---   Haskell code with records in the case of ProductTypes
-toVarBangType :: String -> Field -> Q VarBangType
-toVarBangType name (MkField required fieldTypes _) = do
-  ty' <- ty
-  let newName = mkName . addTickIfNecessary . removeUnderscore $ name
-  pure (newName, Bang TH.NoSourceUnpackedness TH.NoSourceStrictness, ty')
-  where ty = case required of
-          Optional -> [t|Maybe $(mult)|]
-          Required -> mult
-        mult = fieldTypesToNestedEither fieldTypes
 
 -- | Convert field types to Q types
 fieldTypesToNestedEither :: NonEmpty CodeGen.Deserialize.Type -> Q TH.Type


### PR DESCRIPTION
As per #164 and #167, this saves us lines of code and generally
improves nomenclature.