### PR TITLE
Rename Type fields to be commensurate with Datatype.

### DIFF
--- a/tree-sitter/src/CodeGen/Deserialize.hs
+++ b/tree-sitter/src/CodeGen/Deserialize.hs
@@ -79,13 +79,18 @@ instance FromJSON Required where
   parseJSON = withBool "Required" (\p -> pure (if p then Required else Optional))
 
 data Type = MkType
-  { fieldType :: DatatypeName
-  , isNamed :: Named
-  }
-  deriving (Eq, Ord, Show, Generic, ToJSON)
+  { typeName       :: DatatypeName
+  , typeNameStatus :: Named
+  } deriving (Eq, Ord, Show, Generic)
 
 instance FromJSON Type where
-  parseJSON = genericParseJSON customOptions
+  parseJSON = withObject "Type" $ \v ->
+    MkType <$> v .: "type" <*> v .: "named"
+
+instance ToJSON Type where
+  toJSON t = object [ "type"  .= typeName t
+                    , "named" .= typeNameStatus t
+                    ]
 
 newtype DatatypeName = DatatypeName { getDatatypeName :: String }
   deriving (Eq, Ord, Show, Generic)

--- a/tree-sitter/src/CodeGen/GenerateSyntax.hs
+++ b/tree-sitter/src/CodeGen/GenerateSyntax.hs
@@ -18,7 +18,6 @@ module CodeGen.GenerateSyntax
 import Data.Char
 import Language.Haskell.TH as TH
 import Data.HashSet (HashSet)
-import Language.Haskell.TH.Syntax as TH
 import CodeGen.Deserialize (Datatype (..), DatatypeName (..), Field (..), Required (..), Type (..), Named (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Foldable


### PR DESCRIPTION
Since the JSON field names don't lexically map to their record
selectors, we have to implement custom From/ToJSON, which is fine.