### PR TITLE
Remove pointer-only constructors (#146).

### DIFF
--- a/tree-sitter/src/TreeSitter/Cursor.hs
+++ b/tree-sitter/src/TreeSitter/Cursor.hs
@@ -24,9 +24,8 @@ import TreeSitter.Node
 
 -- | A cursor for traversing a tree.
 --
---   Note that we do not define 'Eq', 'Ord', or 'Storable' instances, as the underlying @TSTreeCursor@ type is not usefully copyable.
-data Cursor = Cursor
-  deriving (Show)
+--   This type is uninhabited and used only for type safety within 'Ptr' values.
+data Cursor
 
 withCursor :: Ptr TSNode -> (Ptr Cursor -> IO a) -> IO a
 withCursor rootPtr action = allocaBytes sizeOfCursor $ \ cursor -> Exc.bracket

--- a/tree-sitter/src/TreeSitter/Language.hs
+++ b/tree-sitter/src/TreeSitter/Language.hs
@@ -17,8 +17,10 @@ import           System.Directory
 import           System.FilePath.Posix
 import           TreeSitter.Symbol
 
-newtype Language = Language ()
-  deriving (Show, Eq)
+-- | A tree-sitter language.
+--
+--   This type is uninhabited and used only for type safety within 'Ptr' values.
+data Language
 
 foreign import ccall unsafe "ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> Word32
 foreign import ccall unsafe "ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> CString

--- a/tree-sitter/src/TreeSitter/Parser.hs
+++ b/tree-sitter/src/TreeSitter/Parser.hs
@@ -20,8 +20,10 @@ import Foreign.C
 import TreeSitter.Language
 import TreeSitter.Tree
 
-data Parser = Parser
-  deriving (Show)
+-- | A tree-sitter parser.
+--
+--   This type is uninhabited and used only for type safety within 'Ptr' values.
+data Parser
 
 withParser :: Ptr Language -> (Ptr Parser -> IO a) -> IO a
 withParser language action = Exc.bracket

--- a/tree-sitter/src/TreeSitter/Tree.hs
+++ b/tree-sitter/src/TreeSitter/Tree.hs
@@ -8,8 +8,8 @@ module TreeSitter.Tree
 import Foreign
 import TreeSitter.Node
 
-data Tree = Tree
-  deriving (Show)
+-- | This type is uninhabited and used only for type safety within 'Ptr' values.
+data Tree
 
 withRootNode :: Ptr Tree -> (Ptr Node -> IO a) -> IO a
 withRootNode tree action = alloca $ \ ptr -> do


### PR DESCRIPTION
We didn't export these constructors anyway, so there is no effect on
compatibility here.