### PR TITLE
Build ASTs without dropping fields

### DIFF
--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -76,7 +76,11 @@ instance Unmarshal Text.Text where
 
 instance Unmarshal a => Unmarshal (Maybe a) where
   unmarshalNode = Just <$> unmarshalNode
-  unmarshalEmpty = pure Nothing
+  unmarshalNodes [x] = do
+    goto (nodeTSNode x)
+    Just <$> unmarshalNode
+  unmarshalNodes [] = pure Nothing
+  unmarshalNodes _ = fail "expected 0 or 1 nodes but got multiple"
 
 instance (Unmarshal a, Unmarshal b, SymbolMatching a, SymbolMatching b) => Unmarshal (Either a b) where
   unmarshalNode = do

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -209,7 +209,7 @@ instance GUnmarshal f => GUnmarshal (M1 C c f) where
 
 -- For anonymous leaf nodes:
 instance GUnmarshal U1 where
-  gunmarshalNode node = pure U1
+  gunmarshalNode _ = pure U1
 
 -- For regular leaf nodes
 instance {-# OVERLAPPABLE #-} GUnmarshal (M1 S s (K1 c Text.Text)) where
@@ -217,17 +217,17 @@ instance {-# OVERLAPPABLE #-} GUnmarshal (M1 S s (K1 c Text.Text)) where
 
 -- For unary products:
 instance {-# OVERLAPPABLE #-} (Selector s, Unmarshal k) => GUnmarshal (M1 S s (K1 c k)) where
-  gunmarshalNode node = push $ do
+  gunmarshalNode _ = push $ do
     fields <- getFields
     gunmarshalProductNode fields
 
 -- For sum datatypes:
 instance (GUnmarshalSum f, GUnmarshalSum g, SymbolMatching f, SymbolMatching g) => GUnmarshal (f :+: g) where
-  gunmarshalNode node = gunmarshalSumNode @(f :+: g)
+  gunmarshalNode _ = gunmarshalSumNode @(f :+: g)
 
 -- For product datatypes:
 instance (GUnmarshalProduct f, GUnmarshalProduct g) => GUnmarshal (f :*: g) where
-  gunmarshalNode node = push $ getFields >>= gunmarshalProductNode @(f :*: g)
+  gunmarshalNode _ = push $ getFields >>= gunmarshalProductNode @(f :*: g)
 
 class GUnmarshalSum f where
   gunmarshalSumNode :: (MonadFail m

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -72,9 +72,8 @@ instance Unmarshal Text.Text where
   unmarshalNodes _ = fail "expected a node but got multiple"
 
 instance Unmarshal a => Unmarshal (Maybe a) where
-  unmarshalNodes [x] = Just <$> unmarshalNodes [x]
   unmarshalNodes [] = pure Nothing
-  unmarshalNodes _ = fail "expected 0 or 1 nodes but got multiple"
+  unmarshalNodes listOfNodes = Just <$> unmarshalNodes listOfNodes
 
 instance (Unmarshal a, Unmarshal b, SymbolMatching a, SymbolMatching b) => Unmarshal (Either a b) where
   unmarshalNodes [node] = do

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -164,7 +164,7 @@ peekFieldName = do
     Just . FieldName <$> liftIO (peekCString fieldName)
 
 -- | Return the fields remaining in the current branch, represented as 'Map.Map' of 'FieldName's to their corresponding 'Node's.
-getFields :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m (Map.Map FieldName Node)
+getFields :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m (Map.Map FieldName [Node])
 getFields = go Map.empty -- >>= \fields -> liftIO (print (Map.keys fields)) >> pure fields
   where go fs = do
           node <- peekNode
@@ -173,7 +173,7 @@ getFields = go Map.empty -- >>= \fields -> liftIO (print (Map.keys fields)) >> p
               fieldName <- peekFieldName
               keepGoing <- step
               let fs' = case fieldName of
-                    Just fieldName' -> Map.insert fieldName' node' fs
+                    Just fieldName' -> Map.insertWith (++) fieldName' [node'] fs
                     _ -> fs
               if keepGoing then go fs'
               else pure fs'

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -199,7 +199,7 @@ newtype FieldName = FieldName { getFieldName :: String }
 --
 --   Sum types are constructed by attempting to unmarshal each constructor nondeterministically. This should instead use the current node’s symbol to select the corresponding constructor deterministically.
 class GUnmarshal f where
-  gunmarshalNode :: (MonadFail m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m (f a)
+  gunmarshalNode :: (MonadFail m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => Node -> m (f a)
 
 instance GUnmarshal f => GUnmarshal (M1 D c f) where
   gunmarshalNode = M1 <$> gunmarshalNode

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -37,6 +37,7 @@ import           TreeSitter.Parser as TS
 import           TreeSitter.Tree as TS
 import           Data.Proxy
 import           Prelude hiding (fail)
+import           Data.Maybe (fromMaybe)
 
 -- Parse source code and produce AST
 parseByteString :: Unmarshal t => Ptr TS.Language -> ByteString -> IO (Either String t)
@@ -274,6 +275,4 @@ instance (GUnmarshalProduct f, GUnmarshalProduct g) => GUnmarshalProduct (f :*: 
 -- Contents of product types (ie., the leaves of the product tree)
 instance (Unmarshal k, Selector c) => GUnmarshalProduct (M1 S c (K1 i k)) where
   gunmarshalProductNode fields =
-    case Map.lookup (FieldName (selName @c undefined)) fields of
-      Just nodes -> M1 . K1 <$> unmarshalNodes nodes
-      Nothing -> M1 . K1 <$> unmarshalEmpty
+   M1 . K1 <$> unmarshalNodes (fromMaybe [] (Map.lookup (FieldName (selName @c undefined)) fields))

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -275,7 +275,5 @@ instance (GUnmarshalProduct f, GUnmarshalProduct g) => GUnmarshalProduct (f :*: 
 instance (Unmarshal k, Selector c) => GUnmarshalProduct (M1 S c (K1 i k)) where
   gunmarshalProductNode fields =
     case Map.lookup (FieldName (selName @c undefined)) fields of
-      Just node -> do
-        goto (nodeTSNode node)
-        M1 . K1 <$> unmarshalNode
+      Just nodes -> M1 . K1 <$> unmarshalNodes nodes
       Nothing -> M1 . K1 <$> unmarshalEmpty

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -251,7 +251,7 @@ instance (GUnmarshalSum f, GUnmarshalSum g, SymbolMatching f, SymbolMatching g) 
 
 -- | Generically unmarshal products
 class GUnmarshalProduct f where
-  gunmarshalProductNode :: (MonadFail m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => Map.Map FieldName Node -> m (f a)
+  gunmarshalProductNode :: (MonadFail m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => Map.Map FieldName [Node] -> m (f a)
 
 -- Product structure
 instance (GUnmarshalProduct f, GUnmarshalProduct g) => GUnmarshalProduct (f :*: g) where

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -96,9 +96,6 @@ instance (Unmarshal a, Unmarshal b, SymbolMatching a, SymbolMatching b) => Unmar
         else fail $ showFailure (Proxy @(Either a b)) currentNode
 
 instance Unmarshal a => Unmarshal [a] where
-  -- FIXME: This is wrong. Repeated fields are represented in the tree as multiple nodes with the same field name.
-  --        Currently we only represent a single node for each field name,
-  --        so we only end up keeping the last one encountered in the tree.
   unmarshalNode = pure <$> unmarshalNode
   unmarshalNodes (x:xs) = do
     goto (nodeTSNode x)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -53,9 +53,6 @@ parseByteString language bytestring = withParser language $ \ parser -> withPars
 --
 --   Datatypes which can be constructed from tree-sitter parse trees may use the default definition of 'unmarshalNode' providing that they have a suitable 'Generic' instance.
 class Unmarshal a where
-  -- unmarshalNode :: (MonadFail m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m a
-  -- default unmarshalNode :: (MonadFail m, Carrier sig m, GUnmarshal (Rep a), Generic a, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m a
-  -- unmarshalNode = to <$> gunmarshalNode
 
   unmarshalNodes :: (MonadFail m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => [Node] -> m a
   default unmarshalNodes :: (MonadFail m, Carrier sig m, GUnmarshal (Rep a), Generic a, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => [Node] -> m a

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -63,9 +63,6 @@ class Unmarshal a where
   unmarshalNodes [] = fail "expected a node but didn't get one"
   unmarshalNodes _ = fail "expected a node but got multiple"
 
-  unmarshalEmpty :: MonadFail m => m a
-  unmarshalEmpty = fail "expected a node but didn't get one"
-
 instance Unmarshal Text.Text where
   unmarshalNode = do
     node <- peekNode

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -90,7 +90,6 @@ instance (Unmarshal a, Unmarshal b, SymbolMatching a, SymbolMatching b) => Unmar
 
 instance Unmarshal a => Unmarshal [a] where
   unmarshalNodes (x:xs) = do
-    goto (nodeTSNode x)
     head' <- unmarshalNodes [x]
     tail' <- unmarshalNodes xs
     pure $ head' : tail'

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -56,6 +56,13 @@ class Unmarshal a where
   default unmarshalNode :: (MonadFail m, Carrier sig m, GUnmarshal (Rep a), Generic a, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m a
   unmarshalNode = to <$> gunmarshalNode
 
+  unmarshalNodes :: (MonadFail m, Carrier sig m, Member (Reader ByteString) sig, Member (Reader (Ptr Cursor)) sig, MonadIO m) => [Node] -> m a
+  unmarshalNodes [x] = do
+    goto (nodeTSNode x)
+    unmarshalNode
+  unmarshalNodes [] = fail "expected a node but didn't get one"
+  unmarshalNodes _ = fail "expected a node but got multiple"
+
   unmarshalEmpty :: MonadFail m => m a
   unmarshalEmpty = fail "expected a node but didn't get one"
 

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -98,7 +98,14 @@ instance Unmarshal a => Unmarshal [a] where
   --        Currently we only represent a single node for each field name,
   --        so we only end up keeping the last one encountered in the tree.
   unmarshalNode = pure <$> unmarshalNode
+  unmarshalNodes (x:xs) = do
+    goto (nodeTSNode x)
+    head' <- unmarshalNode
+    tail' <- unmarshalNodes xs
+    pure $ head' : tail'
+  unmarshalNodes [] = pure []
   unmarshalEmpty = pure []
+
 
 class SymbolMatching a where
   symbolMatch :: Proxy a -> Node -> Bool

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -105,7 +105,6 @@ instance Unmarshal a => Unmarshal [a] where
     tail' <- unmarshalNodes xs
     pure $ head' : tail'
   unmarshalNodes [] = pure []
-  unmarshalEmpty = pure []
 
 
 class SymbolMatching a where


### PR DESCRIPTION
Fixes #102

Repeated fields were represented in the tree as multiple nodes with the same field name. We were only representing a single node for each field name, keeping only the last one encountered in the tree. This change fixes that. 