### PR TITLE
Sequence TreeSitter.Language functionality in IO

### DIFF
--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -73,7 +73,7 @@ syntaxDatatype language datatype = case datatype of
 symbolMatchingInstance :: Ptr TS.Language -> Name -> String -> Q [Dec]
 symbolMatchingInstance language name str = do
   tsSymbol <- runIO $ withCString str (pure . TS.ts_language_symbol_for_name language)
-  let tsSymbolType = toEnum $ TS.ts_language_symbol_type language tsSymbol
+  tsSymbolType <- toEnum <$> runIO (TS.ts_language_symbol_type language tsSymbol)
   [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "Expected " <> $(litE (stringL (show name))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))
       symbolMatch _ node = TS.fromTSSymbol (nodeSymbol node) == $(conE (mkName $ "Grammar." <> TS.symbolToName tsSymbolType str))|]

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -72,7 +72,7 @@ syntaxDatatype language datatype = case datatype of
 -- | Create TH-generated SymbolMatching instances for sums, products, leaves
 symbolMatchingInstance :: Ptr TS.Language -> Name -> String -> Q [Dec]
 symbolMatchingInstance language name str = do
-  tsSymbol <- runIO $ withCString str (pure . TS.ts_language_symbol_for_name language)
+  tsSymbol <- runIO $ withCString str (TS.ts_language_symbol_for_name language)
   tsSymbolType <- toEnum <$> runIO (TS.ts_language_symbol_type language tsSymbol)
   [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "Expected " <> $(litE (stringL (show name))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))

--- a/tree-sitter/src/TreeSitter/Language.hs
+++ b/tree-sitter/src/TreeSitter/Language.hs
@@ -23,7 +23,7 @@ newtype Language = Language ()
 foreign import ccall unsafe "ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> IO Word32
 foreign import ccall unsafe "ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> IO CString
 foreign import ccall unsafe "ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> IO Int
-foreign import ccall unsafe "ts_language_symbol_for_name" ts_language_symbol_for_name :: Ptr Language -> CString -> TSSymbol
+foreign import ccall unsafe "ts_language_symbol_for_name" ts_language_symbol_for_name :: Ptr Language -> CString -> IO TSSymbol
 
 -- | TemplateHaskell construction of a datatype for the referenced Language.
 mkSymbolDatatype :: Name -> Ptr Language -> Q [Dec]

--- a/tree-sitter/src/TreeSitter/Language.hs
+++ b/tree-sitter/src/TreeSitter/Language.hs
@@ -17,8 +17,7 @@ import           System.Directory
 import           System.FilePath.Posix
 import           TreeSitter.Symbol
 
-newtype Language = Language ()
-  deriving (Show, Eq)
+data Language
 
 foreign import ccall unsafe "ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> IO Word32
 foreign import ccall unsafe "ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> IO CString

--- a/tree-sitter/src/TreeSitter/Language.hs
+++ b/tree-sitter/src/TreeSitter/Language.hs
@@ -21,7 +21,7 @@ newtype Language = Language ()
   deriving (Show, Eq)
 
 foreign import ccall unsafe "ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> Word32
-foreign import ccall unsafe "ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> CString
+foreign import ccall unsafe "ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> IO CString
 foreign import ccall unsafe "ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> IO Int
 foreign import ccall unsafe "ts_language_symbol_for_name" ts_language_symbol_for_name :: Ptr Language -> CString -> TSSymbol
 
@@ -59,7 +59,8 @@ addDependentFileRelative relativeFile = do
 
 languageSymbols :: Ptr Language -> IO [(SymbolType, String)]
 languageSymbols language = for [0..fromIntegral (pred count)] $ \ symbol -> do
-  name <- peekCString (ts_language_symbol_name language symbol)
+  cname <- ts_language_symbol_name language symbol
+  name <- peekCString cname
   ty <- toEnum <$> ts_language_symbol_type language symbol
   pure (ty, name)
   where count = ts_language_symbol_count language

--- a/tree-sitter/src/TreeSitter/Language.hs
+++ b/tree-sitter/src/TreeSitter/Language.hs
@@ -22,7 +22,7 @@ newtype Language = Language ()
 
 foreign import ccall unsafe "ts_language_symbol_count" ts_language_symbol_count :: Ptr Language -> Word32
 foreign import ccall unsafe "ts_language_symbol_name" ts_language_symbol_name :: Ptr Language -> TSSymbol -> CString
-foreign import ccall unsafe "ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> Int
+foreign import ccall unsafe "ts_language_symbol_type" ts_language_symbol_type :: Ptr Language -> TSSymbol -> IO Int
 foreign import ccall unsafe "ts_language_symbol_for_name" ts_language_symbol_for_name :: Ptr Language -> CString -> TSSymbol
 
 -- | TemplateHaskell construction of a datatype for the referenced Language.
@@ -60,5 +60,6 @@ addDependentFileRelative relativeFile = do
 languageSymbols :: Ptr Language -> IO [(SymbolType, String)]
 languageSymbols language = for [0..fromIntegral (pred count)] $ \ symbol -> do
   name <- peekCString (ts_language_symbol_name language symbol)
-  pure (toEnum (ts_language_symbol_type language symbol), name)
+  ty <- toEnum <$> ts_language_symbol_type language symbol
+  pure (ty, name)
   where count = ts_language_symbol_count language


### PR DESCRIPTION
We were treating these as tho referentially transparent, but it appears that this wasn’t the case: as @aymannadeem & @patrickt diagnosed, sometimes `ts_language_symbol_type` would return 0 when it should have returned 1, specifically when invoked via `cabal v2-haddock` (!).

At the same time, we were getting the correct results from `ts_language_symbol_name`, making me think that the symbol metadata & symbol names arrays might have been initialized at different times… or something. (@maxbrunsfeld, does that sound plausible at all? Could the symbol metadata have been zero-initialized, or get initialized with its correct values on library load or something?)

Either way, this PR fixes this issue and should make builds involving TH (e.g. `tree_sitter_python`) more reliable.