### PR TITLE
Pull in precedence bugfixes from tree-sitter-php.

### DIFF
--- a/tree-sitter-php/tree-sitter-php.cabal
+++ b/tree-sitter-php/tree-sitter-php.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-php
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Tree-sitter grammar/parser for PHP
 description:         This package provides a parser for PHP suitable for use with the tree-sitter package.
 license:             BSD-3-Clause


### PR DESCRIPTION
@KevOrr helped us out with getting some of PHP's more obscure
precedences (like left-associative ternary operators) correct. Let's
pull these changes in so that we get better results in Semantic.