### PR TITLE
Remove hedgehog dependency from tree-sitter:lib.

### DIFF
--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -30,7 +30,6 @@ library
                      , directory            ^>= 1.3
                      , filepath             ^>= 1.4.1
                      , fused-effects         >= 0.4 && <1
-                     , hedgehog              >= 0.6 && <2
                      , split                ^>= 0.2.3
                      , template-haskell      >= 2.12.0.0 && < 2.15.0.0
                      , text                 ^>= 1.2.3.1


### PR DESCRIPTION
As @robrix pointed out, this is not good practice, and we don't even
use `hedgehog` in the library itself, so :fire:.