### PR TITLE
Insert nodes into fields in the correct order

### DIFF
--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -33,5 +33,6 @@ prop_simpleExamples = property $ do
   "pass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right pass] }
   "1" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right one] }
   "expensive" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right function] }
+  "1\npass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right one, Right pass] }
 
 main = checkParallel $$(discover) >>= bool exitFailure exitSuccess

--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -5,12 +5,14 @@ module Main where
 import           TreeSitter.GenerateSyntax
 import           Control.Monad
 import           Control.Monad.IO.Class
+import           Data.Bool (bool)
 import           Data.ByteString (ByteString)
 import           Data.Char
 import           Data.Foldable
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
+import           System.Exit (exitFailure, exitSuccess)
 import           TreeSitter.Python
 import qualified TreeSitter.Python.AST as Py
 import           TreeSitter.Unmarshal
@@ -32,4 +34,4 @@ prop_simpleExamples = property $ do
   "1" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right one] }
   "expensive" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right function] }
 
-main = void $ checkParallel $$(discover)
+main = checkParallel $$(discover) >>= bool exitFailure exitSuccess

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -218,9 +218,9 @@ getFields = go Map.empty -- >>= \fields -> liftIO (print (Map.keys fields)) >> p
               fieldName <- peekFieldName
               keepGoing <- step
               let fs' = case fieldName of
-                    Just fieldName' -> Map.insertWith (++) fieldName' [node'] fs
+                    Just fieldName' -> Map.insertWith (flip (++)) fieldName' [node'] fs
                     _ -> if nodeIsNamed node' /= 0
-                      then Map.insertWith (++) (FieldName "extraChildren") [node'] fs
+                      then Map.insertWith (flip (++)) (FieldName "extraChildren") [node'] fs
                       else fs
               if keepGoing then go fs'
               else pure fs'

--- a/tree-sitter/test-codegen/test-codegen.hs
+++ b/tree-sitter/test-codegen/test-codegen.hs
@@ -5,10 +5,12 @@ module Main where
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
+import Data.Bool (bool)
 import Data.Char
 import TreeSitter.GenerateSyntax
 import Data.Foldable
 import Control.Monad
+import System.Exit (exitFailure, exitSuccess)
 import TreeSitter.Symbol
 
 -- | Generate permutations of alphabet and underscore combinations
@@ -47,4 +49,4 @@ prop_escapePunct = property $ do
   where p = not . (\c -> isSpace c || c == '_' )
 
 main :: IO ()
-main = void $ checkParallel $$(discover)
+main = checkParallel $$(discover) >>= bool exitFailure exitSuccess


### PR DESCRIPTION
`insertWith`, unlike `unionWith`, applies the passed function to the operands in the opposite order to what we expected. This means that we were inserting new nodes at the head of the list every time, and thus reversing the lists of nodes, such that unmarshalling would produce reversed lists.

- [x] Fixes #195.
- [x] Test this.