### PR TITLE
Run the main unit tests using hedgehog instead of hspec

### DIFF
--- a/tree-sitter/test/Spec.hs
+++ b/tree-sitter/test/Spec.hs
@@ -1,47 +1,51 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Main where
+
+import Data.Bool (bool)
+import Control.Monad.IO.Class
 import Foreign
 import Foreign.C.Types
 import Foreign.Storable
-import Test.Hspec
+import Hedgehog
+import System.Exit (exitFailure, exitSuccess)
 import TreeSitter.Cursor
 import TreeSitter.Node
 import TreeSitter.Parser
 
-main :: IO ()
-main = hspec $ do
-  describe "TSNode" $ do
-    it "has the same size as its C counterpart" $
-      sizeOf (undefined :: TSNode) `shouldBe` fromIntegral sizeof_tsnode
+prop_TSNode_sizeOf = property $
+  sizeOf (undefined :: TSNode) === fromIntegral sizeof_tsnode
 
-    it "roundtrips correctly" $
-      with (TSNode 1 2 3 4 nullPtr nullPtr) peek `shouldReturn` TSNode 1 2 3 4 nullPtr nullPtr
+prop_TSNode_roundtrips = property $ do
+  peeked <- liftIO (with (TSNode 1 2 3 4 nullPtr nullPtr) peek)
+  peeked ===              TSNode 1 2 3 4 nullPtr nullPtr
 
-  describe "TSPoint" $ do
-    it "has the same size as its C counterpart" $
-      sizeOf (undefined :: TSPoint) `shouldBe` fromIntegral sizeof_tspoint
+prop_TSPoint_sizeOf = property $
+  sizeOf (undefined :: TSPoint) === fromIntegral sizeof_tspoint
 
-    it "roundtrips correctly" $
-      with (TSPoint 1 2) peek `shouldReturn` TSPoint 1 2
+prop_TSPoint_roundtrips = property $ do
+  peeked <- liftIO (with (TSPoint 1 2) peek)
+  peeked ===              TSPoint 1 2
 
-  describe "Node" $ do
-    it "has the same size as its C counterpart" $
-      sizeOf (undefined :: Node) `shouldBe` fromIntegral sizeof_node
+prop_Node_sizeOf = property $
+  sizeOf (undefined :: Node) === fromIntegral sizeof_node
 
-    it "roundtrips correctly" $
-      with (Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8 9) peek `shouldReturn` Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8 9
+prop_Node_roundtrips = property $ do
+  peeked <- liftIO (with (Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8 9) peek)
+  peeked ===              Node (TSNode 1 2 3 4 nullPtr nullPtr) nullPtr 1 (TSPoint 2 3) (TSPoint 4 5) 6 7 8 9
 
-  describe "TSTreeCursor" $ do
-    it "has the same size as its C counterpart" $
-      sizeOfCursor `shouldBe` fromIntegral sizeof_tstreecursor
+prop_TSTreeCursor_sizeOf = property $
+  sizeOfCursor === fromIntegral sizeof_tstreecursor
 
-  describe "Parser" $ do
-    it "stores a timeout value" $ do
-      parser <- ts_parser_new
-      timeout <- ts_parser_timeout_micros parser
-      timeout `shouldBe` 0
-      ts_parser_set_timeout_micros parser 1000
-      timeout <- ts_parser_timeout_micros parser
-      timeout `shouldBe` 1000
-      ts_parser_delete parser
+prop_Parser_timeout = property $ do
+  parser <- liftIO ts_parser_new
+  timeout <- liftIO (ts_parser_timeout_micros parser)
+  timeout === 0
+  liftIO (ts_parser_set_timeout_micros parser 1000)
+  timeout <- liftIO (ts_parser_timeout_micros parser)
+  timeout === 1000
+  liftIO (ts_parser_delete parser)
+
+main = checkSequential $$(discover) >>= bool exitFailure exitSuccess
 
 foreign import ccall unsafe "src/bridge.c sizeof_tsnode" sizeof_tsnode :: CSize
 foreign import ccall unsafe "src/bridge.c sizeof_tspoint" sizeof_tspoint :: CSize

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -64,7 +64,7 @@ test-suite test
   main-is:             Spec.hs
   build-depends:       base
                      , tree-sitter
-                     , hspec ^>= 2.6.1
+                     , hedgehog >= 0.6 && <2
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 


### PR DESCRIPTION
The `tree-sitter:test` component won’t link for me locally, and I don’t know why. It also seemed a little unnecessary to have all these different test tools in flight, so this PR simplifies things by just using `hedgehog`.