### PR TITLE
Release tree-sitter-0.2.1 and tree-sitter-python-0.3.

### DIFF
--- a/tree-sitter-python/ChangeLog.md
+++ b/tree-sitter-python/ChangeLog.md
@@ -1,0 +1,13 @@
+# v0.3.0.0
+
+* Adds annotation fields to all generated data types. ([#181](https://github.com/tree-sitter/haskell-tree-sitter/pull/181))
+* Fixes bug where nodes would be inserted into fields in reverse order. ([#195](https://github.com/tree-sitter/haskell-tree-sitter/issues/195))
+* Pulled latest tree-sitter grammar.
+
+# v0.2.0.0
+
+* Adds `extraChildren` field to all applicable data types. ([#179](https://github.com/tree-sitter/haskell-tree-sitter/pull/179))
+
+# v0.1.0.0
+
+* Initial release.

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -11,6 +11,7 @@ copyright:           2017 GitHub
 category:            Tree-sitter, Python
 build-type:          Simple
 data-files:          vendor/tree-sitter-python/src/node-types.json
+extra-source-files:  ChangeLog.md
 
 library
   exposed-modules:     TreeSitter.Python

--- a/tree-sitter/ChangeLog.md
+++ b/tree-sitter/ChangeLog.md
@@ -1,0 +1,12 @@
+# v0.2.1.0
+
+* Add `TreeSitter.Range` and `TreeSitter.Span`.
+
+# v0.2.0.0
+
+* Add unmarshalling support with `TreeSitter.Unmarshal`.
+* Removes pointer-only constructor.
+
+# v0.1.0.0
+
+* Initial release.

--- a/tree-sitter/ChangeLog.md
+++ b/tree-sitter/ChangeLog.md
@@ -5,7 +5,7 @@
 # v0.2.0.0
 
 * Add unmarshalling support with `TreeSitter.Unmarshal`.
-* Removes pointer-only constructor.
+* Removes pointer-only constructors for bridged C types.
 
 # v0.1.0.0
 

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            Unstable bindings for the tree-sitter parsing library.
 description:         Tree-sitter is a parser generator tool and an incremental parsing library.
                      .
@@ -20,6 +20,7 @@ extra-source-files:  vendor/tree-sitter/lib/src/*.c
                    , vendor/tree-sitter/lib/src/*.h
                    , vendor/tree-sitter/lib/utf8proc/utf8proc.c
                    , vendor/tree-sitter/lib/utf8proc/utf8proc_data.c
+                   , ChangeLog.md
 
 library
   hs-source-dirs:      src


### PR DESCRIPTION
I took the liberty of adding changelog files because I was sick of the
Hackage candidate page chastising me for their absence.

When this lands, I will push up `tree-sitter-0.2.1.0` and
`tree-sitter-python-0.3.0.0` tags.

This will allow `semantic-python` to ingest that good good annotation info.