### PR TITLE
Narrow version bounds and release tree-sitter-python-0.3.

### DIFF
--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -17,7 +17,7 @@ library
   exposed-modules:     TreeSitter.Python
                      , TreeSitter.Python.AST
   build-depends:       base              >= 4.12 && < 5
-                     , tree-sitter      ^>= 0.2
+                     , tree-sitter       == 0.2.1.0
                      , aeson            ^>= 1.4.2.0
                      , directory        ^>= 1.3
                      , filepath         ^>= 1.4
@@ -32,7 +32,7 @@ library tree-sitter-python-internal
   exposed-modules:     TreeSitter.Python.Internal
   hs-source-dirs:      internal
   build-depends:       base         >= 4.12 && < 5
-                     , tree-sitter ^>= 0.2
+                     , tree-sitter  == 0.2.1.0
   default-language:    Haskell2010
   Include-dirs:        vendor/tree-sitter-python/src
   install-includes:    tree_sitter/parser.h


### PR DESCRIPTION
For paranoia's sake, let's use exact version bounds for releases that
depend very specifically on the output from a tree-sitter macro.