### PR TITLE
No more eithers

### DIFF
--- a/tree-sitter-python/TreeSitter/Python/AST.hs
+++ b/tree-sitter-python/TreeSitter/Python/AST.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric, DuplicateRecordFields, TemplateHaskell, TypeApplications #-}
+{-# LANGUAGE DeriveAnyClass, DeriveGeneric, DeriveTraversable, DuplicateRecordFields, TemplateHaskell, TypeApplications #-}
 module TreeSitter.Python.AST where
 
 import TreeSitter.GenerateSyntax

--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -16,6 +16,7 @@ import           System.Exit (exitFailure, exitSuccess)
 import           TreeSitter.Python
 import qualified TreeSitter.Python.AST as Py
 import           TreeSitter.Unmarshal
+import           GHC.Generics
 
 -- TODO: add tests that verify correctness for product, sum and leaf types
 
@@ -25,16 +26,18 @@ s `shouldParseInto` t = do
   parsed === Right t
 
 pass = Py.PassStatementSimpleStatement (Py.PassStatement () "pass" )
-one = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [Left (Py.PrimaryExpressionExpression (Py.IntegerPrimaryExpression (Py.Integer () "1")))])
-function = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [Left (Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier () "expensive")))])
+one = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.IntegerPrimaryExpression (Py.Integer () "1")))])
+function = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier () "expensive")))])
 
 prop_simpleExamples :: Property
 prop_simpleExamples = property $ do
   "" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [] }
   "# bah" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [] }
-  "pass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right pass] }
-  "1" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right one] }
-  "expensive" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right function] }
-  "1\npass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [Right one, Right pass] }
+  "pass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 pass] }
+  "1" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 one] }
+  "expensive" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 function] }
+  "1\npass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 one, R1 pass] }
+
+
 
 main = checkParallel $$(discover) >>= bool exitFailure exitSuccess

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -129,11 +129,11 @@ ctorForTypes named constructorName types = recC (toName named constructorName) r
 
 -- | Convert field types to Q types
 fieldTypesToNestedEither :: NonEmpty TreeSitter.Deserialize.Type -> Name -> Q TH.Type
-fieldTypesToNestedEither xs typeParameterName = foldr1 combine $ fmap convertToQType xs
+fieldTypesToNestedEither xs typeParameterName = foldr1 combine (fmap convertToQType xs) `appT` varT typeParameterName
   where
-    combine convertedQType = appT (appT (conT ''Either) convertedQType)
-    convertToQType (MkType (DatatypeName n) named) = appT (conT (toName named n)) (varT typeParameterName)
-    -- TODO: pull convertToQType out to top-level fn
+    combine lhs rhs = (conT ''(:+:) `appT` lhs) `appT` rhs
+    convertToQType (MkType (DatatypeName n) named) = conT (toName named n)
+
 
 -- | Create bang required to build records
 strictness :: BangQ

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -67,7 +67,7 @@ syntaxDatatype language datatype = do
         Named -> generatedDatatype name [con] typeParameterName:result
   where
     name = toName (datatypeNameStatus datatype) (getDatatypeName (TreeSitter.Deserialize.datatypeName datatype))
-    deriveClause = [ DerivClause Nothing [ ConT ''TS.Unmarshal, ConT ''Eq, ConT ''Ord, ConT ''Show, ConT ''Generic ] ]
+    deriveClause = [ DerivClause Nothing [ ConT ''TS.Unmarshal, ConT ''Eq, ConT ''Ord, ConT ''Show, ConT ''Generic, ConT ''Foldable, ConT ''Functor, ConT ''Traversable, ConT ''Generic1] ]
     generatedDatatype name cons typeParameterName = DataD [] name [PlainTV typeParameterName] Nothing cons deriveClause
 
 

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -147,10 +147,6 @@ instance SymbolMatching a => SymbolMatching (Maybe a) where
   symbolMatch _ = symbolMatch (Proxy @a)
   showFailure _ = showFailure (Proxy @a)
 
-instance (SymbolMatching a, SymbolMatching b) => SymbolMatching (Either a b) where
-  symbolMatch _ = (||) <$> symbolMatch (Proxy @a) <*> symbolMatch (Proxy @b)
-  showFailure _ = sep <$> showFailure (Proxy @a) <*> showFailure (Proxy @b)
-
 instance SymbolMatching a => SymbolMatching [a] where
   symbolMatch _ = symbolMatch (Proxy @a)
   showFailure _ = showFailure (Proxy @a)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -109,17 +109,17 @@ instance Unmarshal a => Unmarshal (Maybe a) where
   unmarshalNodes [] = pure Nothing
   unmarshalNodes listOfNodes = Just <$> unmarshalNodes listOfNodes
 
-instance (Unmarshal a, Unmarshal b, SymbolMatching a, SymbolMatching b) => Unmarshal (Either a b) where
+instance (Unmarshal (f a), Unmarshal (g a), SymbolMatching (f a), SymbolMatching (g a)) => Unmarshal ((f :+: g) a) where
   unmarshalNodes [node] = do
-    let lhsSymbolMatch = symbolMatch (Proxy @a) node
-        rhsSymbolMatch = symbolMatch (Proxy @b) node
+    let lhsSymbolMatch = symbolMatch (Proxy @(f a)) node
+        rhsSymbolMatch = symbolMatch (Proxy @(g a)) node
     if lhsSymbolMatch
-      then Left <$> unmarshalNodes @a [node]
+      then L1 <$> unmarshalNodes @(f a) [node]
       else if rhsSymbolMatch
-        then Right <$> unmarshalNodes @b [node]
-        else fail $ showFailure (Proxy @(Either a b)) node
-  unmarshalNodes [] = fail "expected a node of type (Either a b) but didn't get one"
-  unmarshalNodes _ = fail "expected a node of type (Either a b) but got multiple"
+        then R1 <$> unmarshalNodes @(g a) [node]
+        else fail $ showFailure (Proxy @((f :+: g) a)) node
+  unmarshalNodes [] = fail "expected a node of type ((f :+: g) a) but didn't get one"
+  unmarshalNodes _ = fail "expected a node of type ((f :+: g) a) but got multiple"
 
 
 instance Unmarshal a => Unmarshal [a] where

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -163,6 +163,10 @@ instance (SymbolMatching f, SymbolMatching g) => SymbolMatching (f :+: g) where
   symbolMatch _ = (||) <$> symbolMatch (Proxy @f) <*> symbolMatch (Proxy @g)
   showFailure _ = sep <$> showFailure (Proxy @f) <*> showFailure (Proxy @g)
 
+instance (SymbolMatching (f a), SymbolMatching (g a)) => SymbolMatching ((f :+: g) a) where
+  symbolMatch _ = (||) <$> symbolMatch (Proxy @(f a)) <*> symbolMatch (Proxy @(g a))
+  showFailure _ = sep <$> showFailure (Proxy @(f a)) <*> showFailure (Proxy @(g a))
+
 sep :: String -> String -> String
 sep a b = a ++ ". " ++ b
 


### PR DESCRIPTION
Fixes #197, #209, #182 

This PR replaces the use of the `Either` type with `:+:` for anonymous sums. This has a few effects:
1. **The shape of our data changes.** A given anonymous sum represented with `Either` looks like this: `Either (X a) (Y a)`, with the type parameter `a` being applied "inside". By contrast, the use of `:+:` would give us `(X :+: Y) a`, where the constructors are summed and then applied to the type parameter. 
2. **The kind signature changes.** `Either` is `* -> * -> *`: it takes two fully-applied types and gives you a fully-applied type, whereas `:+:` is `(* -> *) -> (* -> *) -> (* -> *)`:  it takes two type constructors and gives you a type constructor. This allows @patrickt to define a `Compile` interface to be of `* -> *` instead of `*`.
3. **We can now derive instances for a bunch of typeclasses.** The generated syntax types now automatically derive `Foldable`, `Functor`, `Traversable` and `Generic1`, with the `Generic1` instance being specifically helpful to some of @robrix' work on `semantic-tags`. To be able to derive instances of these typeclasses required the type parameter being in the final position, which was impossible before (because `Either (X a) (Y a)`), but is now possible (because `(X :+: Y) a`).

Oh, and I need to fix tests to account for the new shape. 