### PR TITLE
Unmarshal at * -> *

### DIFF
--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -20,7 +20,7 @@ import           GHC.Generics
 
 -- TODO: add tests that verify correctness for product, sum and leaf types
 
-shouldParseInto :: (MonadIO m, MonadTest m, Unmarshal t, Eq t, Show t) => ByteString -> t -> m ()
+shouldParseInto :: (MonadIO m, MonadTest m, Unmarshal t, UnmarshalAnn a, Eq (t a), Show (t a)) => ByteString -> t a -> m ()
 s `shouldParseInto` t = do
   parsed <- liftIO $ parseByteString tree_sitter_python s
   parsed === Right t

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -53,7 +53,7 @@ syntaxDatatype language datatype = do
   case datatype of
     SumType (DatatypeName datatypeName) _ subtypes -> do
       cons <- traverse (constructorForSumChoice datatypeName typeParameterName) subtypes
-      result <- symbolMatchingInstanceForSums language name subtypes
+      result <- symbolMatchingInstanceForSums name subtypes
       pure $ generatedDatatype name cons typeParameterName:result
     ProductType (DatatypeName datatypeName) _ children fields -> do
       con <- ctorForProductType datatypeName typeParameterName children fields
@@ -80,8 +80,8 @@ symbolMatchingInstance language name str = do
       showFailure _ node = "Expected " <> $(litE (stringL (show name))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))
       symbolMatch _ node = TS.fromTSSymbol (nodeSymbol node) == $(conE (mkName $ "Grammar." <> TS.symbolToName tsSymbolType str))|]
 
-symbolMatchingInstanceForSums :: Ptr TS.Language -> Name -> [TreeSitter.Deserialize.Type] -> Q [Dec]
-symbolMatchingInstanceForSums _ name subtypes =
+symbolMatchingInstanceForSums :: Name -> [TreeSitter.Deserialize.Type] -> Q [Dec]
+symbolMatchingInstanceForSums name subtypes =
   [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "Expected " <> $(litE (stringL (show (map extractn subtypes)))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))
       symbolMatch _ = $(foldr1 mkOr (perMkType `map` subtypes)) |]

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -76,16 +76,16 @@ symbolMatchingInstance :: Ptr TS.Language -> Name -> String -> Name -> Q [Dec]
 symbolMatchingInstance language name str typeParameterName = do
   tsSymbol <- runIO $ withCString str (TS.ts_language_symbol_for_name language)
   tsSymbolType <- toEnum <$> runIO (TS.ts_language_symbol_type language tsSymbol)
-  [d|instance TS.SymbolMatching $(appT (conT name) (varT typeParameterName)) where
+  [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "Expected " <> $(litE (stringL (show name))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))
       symbolMatch _ node = TS.fromTSSymbol (nodeSymbol node) == $(conE (mkName $ "Grammar." <> TS.symbolToName tsSymbolType str))|]
 
 symbolMatchingInstanceForSums ::  Ptr TS.Language -> Name -> [TreeSitter.Deserialize.Type] -> Name -> Q [Dec]
 symbolMatchingInstanceForSums _ name subtypes typeParameterName =
-  [d|instance TS.SymbolMatching $(appT (conT name) (varT typeParameterName)) where
+  [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "Expected " <> $(litE (stringL (show (map extractn subtypes)))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))
       symbolMatch _ = $(foldr1 mkOr (perMkType `map` subtypes)) |]
-  where perMkType (MkType (DatatypeName n) named) = [e|TS.symbolMatch (Proxy :: Proxy $(appT (conT (toName named n)) (varT typeParameterName))) |]
+  where perMkType (MkType (DatatypeName n) named) = [e|TS.symbolMatch (Proxy :: Proxy $(conT (toName named n))) |]
         mkOr lhs rhs = [e| (||) <$> $(lhs) <*> $(rhs) |]
         extractn (MkType (DatatypeName n) Named) = toCamelCase n
         extractn (MkType (DatatypeName n) Anonymous) = "Anonymous" <> toCamelCase n

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -53,15 +53,15 @@ syntaxDatatype language datatype = do
   case datatype of
     SumType (DatatypeName datatypeName) _ subtypes -> do
       cons <- traverse (constructorForSumChoice datatypeName typeParameterName) subtypes
-      result <- symbolMatchingInstanceForSums language name subtypes typeParameterName
+      result <- symbolMatchingInstanceForSums language name subtypes
       pure $ generatedDatatype name cons typeParameterName:result
     ProductType (DatatypeName datatypeName) _ children fields -> do
       con <- ctorForProductType datatypeName typeParameterName children fields
-      result <- symbolMatchingInstance language name datatypeName typeParameterName
+      result <- symbolMatchingInstance language name datatypeName
       pure $ generatedDatatype name [con] typeParameterName:result
     LeafType (DatatypeName datatypeName) named -> do
       con <- ctorForLeafType named (DatatypeName datatypeName) typeParameterName
-      result <- symbolMatchingInstance language name datatypeName typeParameterName
+      result <- symbolMatchingInstance language name datatypeName
       pure $ case named of
         Anonymous -> NewtypeD [] name [PlainTV typeParameterName] Nothing con deriveClause:result
         Named -> generatedDatatype name [con] typeParameterName:result
@@ -72,16 +72,16 @@ syntaxDatatype language datatype = do
 
 
 -- | Create TH-generated SymbolMatching instances for sums, products, leaves
-symbolMatchingInstance :: Ptr TS.Language -> Name -> String -> Name -> Q [Dec]
-symbolMatchingInstance language name str typeParameterName = do
+symbolMatchingInstance :: Ptr TS.Language -> Name -> String -> Q [Dec]
+symbolMatchingInstance language name str = do
   tsSymbol <- runIO $ withCString str (TS.ts_language_symbol_for_name language)
   tsSymbolType <- toEnum <$> runIO (TS.ts_language_symbol_type language tsSymbol)
   [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "Expected " <> $(litE (stringL (show name))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))
       symbolMatch _ node = TS.fromTSSymbol (nodeSymbol node) == $(conE (mkName $ "Grammar." <> TS.symbolToName tsSymbolType str))|]
 
-symbolMatchingInstanceForSums ::  Ptr TS.Language -> Name -> [TreeSitter.Deserialize.Type] -> Name -> Q [Dec]
-symbolMatchingInstanceForSums _ name subtypes typeParameterName =
+symbolMatchingInstanceForSums :: Ptr TS.Language -> Name -> [TreeSitter.Deserialize.Type] -> Q [Dec]
+symbolMatchingInstanceForSums _ name subtypes =
   [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "Expected " <> $(litE (stringL (show (map extractn subtypes)))) <> " but got " <> show (TS.fromTSSymbol (nodeSymbol node) :: $(conT (mkName "Grammar.Grammar")))
       symbolMatch _ = $(foldr1 mkOr (perMkType `map` subtypes)) |]

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -38,7 +38,7 @@ import           Source.Span
 import           Source.Range
 import           Data.Proxy
 import           Prelude hiding (fail)
-import           Data.Maybe (fromMaybe, maybeToList)
+import           Data.Maybe (fromMaybe)
 import           Data.List.NonEmpty (NonEmpty (..))
 
 -- Parse source code and produce AST
@@ -49,7 +49,7 @@ parseByteString language bytestring = withParser language $ \ parser -> withPars
   else
     withRootNode treePtr $ \ rootPtr ->
       withCursor (castPtr rootPtr) $ \ cursor ->
-        runM (runFail (runReader cursor (runReader bytestring (peekNode >>= unmarshalNodes . maybeToList))))
+        runM (runFail (runReader cursor (runReader bytestring (peekNode >>= maybe (fail "expected a root node") unmarshalNode))))
 
 -- | Unmarshal is the process of iterating over tree-sitter’s parse trees using its tree cursor API and producing Haskell ASTs for the relevant nodes.
 --

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -4,6 +4,8 @@ module TreeSitter.Unmarshal
 ( parseByteString
 , FieldName(..)
 , Unmarshal(..)
+, UnmarshalAnn(..)
+, UnmarshalField(..)
 , SymbolMatching(..)
 , step
 , push

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -297,10 +297,7 @@ class GUnmarshal f where
     => Node
     -> m (f a)
 
-instance GUnmarshal f => GUnmarshal (M1 D c f) where
-  gunmarshalNode node = M1 <$> gunmarshalNode node
-
-instance GUnmarshal f => GUnmarshal (M1 C c f) where
+instance GUnmarshal f => GUnmarshal (M1 i c f) where
   gunmarshalNode node = M1 <$> gunmarshalNode node
 
 -- For anonymous leaf nodes:
@@ -309,12 +306,12 @@ instance GUnmarshal U1 where
 
 
 -- For unary products:
-instance (Selector s, UnmarshalAnn k) => GUnmarshal (M1 S s (K1 c k)) where
-  gunmarshalNode node = push getFields >>= gunmarshalProductNode node . fromMaybe Map.empty
+instance UnmarshalAnn k => GUnmarshal (K1 c k) where
+  gunmarshalNode node = K1 <$> unmarshalAnn node
 
 -- For anonymous leaf nodes
-instance GUnmarshal (M1 S s Par1) where
-  gunmarshalNode = fmap (M1 . Par1) <$> unmarshalAnn
+instance GUnmarshal Par1 where
+  gunmarshalNode node = Par1 <$> unmarshalAnn node
 
 -- For sum datatypes:
 instance (GUnmarshalSum f, GUnmarshalSum g, SymbolMatching f, SymbolMatching g) => GUnmarshal (f :+: g) where

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -63,6 +63,7 @@ class Unmarshal a where
     to <$> gunmarshalNode x
   unmarshalNodes [] = fail "expected a node but didn't get one"
   unmarshalNodes _ = fail "expected a node but got multiple"
+
 class UnmarshalAnn a where
   unmarshalAnn
     :: ( Carrier sig m
@@ -73,6 +74,7 @@ class UnmarshalAnn a where
        )
     => Node
     -> m a
+
 
 class UnmarshalField t where
   unmarshalField

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -168,20 +168,6 @@ instance UnmarshalField NonEmpty where
   unmarshalField [] = fail "expected a node but didn't get one"
 
 
-instance Unmarshal () where
-  unmarshalNodes _ = pure ()
-
-instance Unmarshal Span where
-  unmarshalNodes _ = do
-    node <- peekNode
-    case node of
-      Just node -> do
-        let spanStart = pointToPos (nodeStartPoint node)
-            spanEnd = pointToPos (nodeEndPoint node)
-        pure (Span spanStart spanEnd)
-      Nothing -> fail "expected a node but didn't get one"
-
-
 class SymbolMatching a where
   symbolMatch :: Proxy a -> Node -> Bool
 

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -233,14 +233,11 @@ peekNode :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m (M
 peekNode = do
   cursor <- ask
   liftIO $ alloca $ \ tsNodePtr -> do
-    isValid <- ts_tree_cursor_current_node_p cursor tsNodePtr
-    if isValid then do
-      node <- alloca $ \ nodePtr -> do
-        ts_node_poke_p tsNodePtr nodePtr
-        peek nodePtr
-      pure (Just node)
-    else
-      pure Nothing
+    _ <- ts_tree_cursor_current_node_p cursor tsNodePtr
+    node <- alloca $ \ nodePtr -> do
+      ts_node_poke_p tsNodePtr nodePtr
+      peek nodePtr
+    pure (Just node)
 
 -- | Return the field name (if any) for the node that the cursor is pointing at (if any), or 'Nothing' otherwise.
 peekFieldName :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m (Maybe FieldName)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -385,11 +385,15 @@ instance GUnmarshalProduct (M1 S c Par1) where
 
 instance (UnmarshalField f, Unmarshal g, Selector c) => GUnmarshalProduct (M1 S c (f :.: g)) where
   gunmarshalProductNode _ fields =
-    M1 . Comp1 <$> unmarshalField (fromMaybe [] (Map.lookup (FieldName (selName @c undefined)) fields))
+    M1 . Comp1 <$> unmarshalField (getField (FieldName (selName @c undefined)) fields)
 
 instance (Unmarshal t, Selector c) => GUnmarshalProduct (M1 S c (Rec1 t)) where
   gunmarshalProductNode _ fields =
-    case fromMaybe [] (Map.lookup (FieldName (selName @c undefined)) fields) of
+    case getField (FieldName (selName @c undefined)) fields of
       []  -> fail "expected a node but didn't get one"
       [x] -> M1 . Rec1 <$> unmarshalNode x
       _   -> fail "expected a node but got multiple"
+
+
+getField :: FieldName -> Fields -> [Node]
+getField k = fromMaybe [] . Map.lookup k

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -313,12 +313,12 @@ instance UnmarshalAnn k => GUnmarshal (K1 c k) where
 instance GUnmarshal Par1 where
   gunmarshalNode node = Par1 <$> unmarshalAnn node
 
+instance (Unmarshal t, SymbolMatching t) => GUnmarshal (Rec1 t) where
+  gunmarshalNode node = Rec1 <$> unmarshalNode node
+
 -- For product datatypes:
 instance (GUnmarshalProduct f, GUnmarshalProduct g) => GUnmarshal (f :*: g) where
   gunmarshalNode node = push getFields >>= gunmarshalProductNode @(f :*: g) node . fromMaybe Map.empty
-
-instance (Unmarshal t, SymbolMatching t) => GUnmarshal (Rec1 t) where
-  gunmarshalNode node = Rec1 <$> unmarshalNode node
 
 -- For sum datatypes:
 instance (GUnmarshal f, GUnmarshal g, SymbolMatching f, SymbolMatching g) => GUnmarshal (f :+: g) where

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -53,7 +53,7 @@ parseByteString language bytestring = withParser language $ \ parser -> withPars
 
 -- | Unmarshalling is the process of iterating over tree-sitter’s parse trees using its tree cursor API and producing Haskell ASTs for the relevant nodes.
 --
---   Datatypes which can be constructed from tree-sitter parse trees may use the default definition of 'unmarshalNode' providing that they have a suitable 'Generic' instance.
+--   Datatypes which can be constructed from tree-sitter parse trees may use the default definition of 'unmarshalNode' providing that they have a suitable 'Generic1' instance.
 class Unmarshal t where
   unmarshalNode
     :: ( Carrier sig m

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -87,6 +87,11 @@ class UnmarshalField t where
     => [Node]
     -> m (t (f a))
 
+instance UnmarshalField Maybe where
+  unmarshalField []  = pure Nothing
+  unmarshalField [x] = Just <$> unmarshalNode x
+  unmarshalField _   = fail "expected a node of type ((f :+: g) a) but got multiple"
+
 
 instance Unmarshal () where
   unmarshalNodes _ = pure ()

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -115,9 +115,9 @@ instance UnmarshalAnn () where
 
 instance UnmarshalAnn Text.Text where
   unmarshalAnn node = do
-    Range start end <- unmarshalAnn node
+    range <- unmarshalAnn node
     bytestring <- ask
-    pure (decodeUtf8 (slice start end bytestring))
+    pure (decodeUtf8 (slice range bytestring))
 
 -- | Instance for pairs of annotations
 instance (UnmarshalAnn a, UnmarshalAnn b) => UnmarshalAnn (a,b) where
@@ -268,8 +268,8 @@ getFields = go Map.empty
           else pure fs'
 
 -- | Return a 'ByteString' that contains a slice of the given 'ByteString'.
-slice :: Int -> Int -> ByteString -> ByteString
-slice start end = take . drop
+slice :: Range -> ByteString -> ByteString
+slice (Range start end) = take . drop
   where drop = B.drop start
         take = B.take (end - start)
 

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -75,6 +75,9 @@ class UnmarshalAnn a where
     => Node
     -> m a
 
+instance UnmarshalAnn () where
+  unmarshalAnn _ = pure ()
+
 
 class UnmarshalField t where
   unmarshalField

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -96,6 +96,12 @@ instance UnmarshalAnn Range where
         end   = fromIntegral (nodeEndByte node)
     pure (Range start end)
 
+instance UnmarshalAnn Span where
+  unmarshalAnn node = do
+    let spanStart = pointToPos (nodeStartPoint node)
+        spanEnd   = pointToPos (nodeEndPoint node)
+    pure (Span spanStart spanEnd)
+
 
 class UnmarshalField t where
   unmarshalField

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -159,10 +159,6 @@ instance (SymbolMatching f, SymbolMatching g) => SymbolMatching (f :+: g) where
   symbolMatch _ = (||) <$> symbolMatch (Proxy @f) <*> symbolMatch (Proxy @g)
   showFailure _ = sep <$> showFailure (Proxy @f) <*> showFailure (Proxy @g)
 
-instance (SymbolMatching (f a), SymbolMatching (g a)) => SymbolMatching ((f :+: g) a) where
-  symbolMatch _ = (||) <$> symbolMatch (Proxy @(f a)) <*> symbolMatch (Proxy @(g a))
-  showFailure _ = sep <$> showFailure (Proxy @(f a)) <*> showFailure (Proxy @(g a))
-
 sep :: String -> String -> String
 sep a b = a ++ ". " ++ b
 

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -269,8 +269,8 @@ getFields = go Map.empty
           if keepGoing then go fs'
           else pure fs'
 
-getField :: FieldName -> Fields -> [Node]
-getField k = fromMaybe [] . Map.lookup k
+lookupField :: FieldName -> Fields -> [Node]
+lookupField k = fromMaybe [] . Map.lookup k
 
 
 -- | Return a 'ByteString' that contains a slice of the given 'ByteString'.
@@ -366,11 +366,11 @@ instance GUnmarshalProduct (M1 S c Par1) where
 
 instance (UnmarshalField f, Unmarshal g, Selector c) => GUnmarshalProduct (M1 S c (f :.: g)) where
   gunmarshalProductNode _ fields =
-    M1 . Comp1 <$> unmarshalField (getField (FieldName (selName @c undefined)) fields)
+    M1 . Comp1 <$> unmarshalField (lookupField (FieldName (selName @c undefined)) fields)
 
 instance (Unmarshal t, Selector c) => GUnmarshalProduct (M1 S c (Rec1 t)) where
   gunmarshalProductNode _ fields =
-    case getField (FieldName (selName @c undefined)) fields of
+    case lookupField (FieldName (selName @c undefined)) fields of
       []  -> fail "expected a node but didn't get one"
       [x] -> M1 . Rec1 <$> unmarshalNode x
       _   -> fail "expected a node but got multiple"

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -183,14 +183,6 @@ class SymbolMatching a where
   -- | Provide error message describing the node symbol vs. the symbols this can match
   showFailure :: Proxy a -> Node -> String
 
-instance SymbolMatching a => SymbolMatching (Maybe a) where
-  symbolMatch _ = symbolMatch (Proxy @a)
-  showFailure _ = showFailure (Proxy @a)
-
-instance SymbolMatching a => SymbolMatching [a] where
-  symbolMatch _ = symbolMatch (Proxy @a)
-  showFailure _ = showFailure (Proxy @a)
-
 instance SymbolMatching f => SymbolMatching (M1 i c f) where
   symbolMatch _ = symbolMatch (Proxy @f)
   showFailure _ = showFailure (Proxy @f)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -269,6 +269,10 @@ getFields = go Map.empty
           if keepGoing then go fs'
           else pure fs'
 
+getField :: FieldName -> Fields -> [Node]
+getField k = fromMaybe [] . Map.lookup k
+
+
 -- | Return a 'ByteString' that contains a slice of the given 'ByteString'.
 slice :: Range -> ByteString -> ByteString
 slice (Range start end) = take . drop
@@ -370,7 +374,3 @@ instance (Unmarshal t, Selector c) => GUnmarshalProduct (M1 S c (Rec1 t)) where
       []  -> fail "expected a node but didn't get one"
       [x] -> M1 . Rec1 <$> unmarshalNode x
       _   -> fail "expected a node but got multiple"
-
-
-getField :: FieldName -> Fields -> [Node]
-getField k = fromMaybe [] . Map.lookup k

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -63,6 +63,17 @@ class Unmarshal a where
     to <$> gunmarshalNode x
   unmarshalNodes [] = fail "expected a node but didn't get one"
   unmarshalNodes _ = fail "expected a node but got multiple"
+class UnmarshalAnn a where
+  unmarshalAnn
+    :: ( Carrier sig m
+       , Member (Reader ByteString) sig
+       , Member (Reader (Ptr Cursor)) sig
+       , MonadFail m
+       , MonadIO m
+       )
+    => Node
+    -> m a
+
 
 instance Unmarshal () where
   unmarshalNodes _ = pure ()

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -102,6 +102,9 @@ instance UnmarshalAnn Span where
         spanEnd   = pointToPos (nodeEndPoint node)
     pure (Span spanStart spanEnd)
 
+pointToPos :: TSPoint -> Pos
+pointToPos (TSPoint line column) = Pos (fromIntegral line) (fromIntegral column)
+
 
 class UnmarshalField t where
   unmarshalField
@@ -174,8 +177,6 @@ instance Unmarshal Span where
         pure (Span spanStart spanEnd)
       Nothing -> fail "expected a node but didn't get one"
 
-pointToPos :: TSPoint -> Pos
-pointToPos (TSPoint line column) = Pos (fromIntegral line) (fromIntegral column)
 
 instance Unmarshal a => Unmarshal (Maybe a) where
   unmarshalNodes [] = pure Nothing

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -141,6 +141,7 @@ pointToPos :: TSPoint -> Pos
 pointToPos (TSPoint line column) = Pos (fromIntegral line) (fromIntegral column)
 
 
+-- | Optional/repeated fields occurring in product datatypes are wrapped in type constructors, e.g. 'Maybe', '[]', or 'NonEmpty', and thus can unmarshal zero or more nodes for the same field name.
 class UnmarshalField t where
   unmarshalField
     :: ( Carrier sig m

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -96,6 +96,9 @@ instance Unmarshal t => Unmarshal (Rec1 t) where
   unmarshalNode = fmap Rec1 . unmarshalNode
 
 
+-- | Unmarshal an annotation field.
+--
+--   Leaf nodes have 'Text.Text' fields, and leaves, anonymous leaves, and products all have parametric annotation fields. All of these fields are unmarshalled using the metadata of the node, e.g. its start/end bytes, without reference to any child nodes it may contain.
 class UnmarshalAnn a where
   unmarshalAnn
     :: ( Carrier sig m

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -90,6 +90,12 @@ instance (UnmarshalAnn a, UnmarshalAnn b) => UnmarshalAnn (a,b) where
     <$> unmarshalAnn @a node
     <*> unmarshalAnn @b node
 
+instance UnmarshalAnn Range where
+  unmarshalAnn node = do
+    let start = fromIntegral (nodeStartByte node)
+        end   = fromIntegral (nodeEndByte node)
+    pure (Range start end)
+
 
 class UnmarshalField t where
   unmarshalField

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -42,7 +42,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.List.NonEmpty (NonEmpty (..))
 
 -- Parse source code and produce AST
-parseByteString :: Unmarshal t => Ptr TS.Language -> ByteString -> IO (Either String t)
+parseByteString :: (Unmarshal t, UnmarshalAnn a) => Ptr TS.Language -> ByteString -> IO (Either String (t a))
 parseByteString language bytestring = withParser language $ \ parser -> withParseTree parser bytestring $ \ treePtr ->
   if treePtr == nullPtr then
     pure (Left "error: didn't get a root node")

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -92,6 +92,9 @@ instance (Unmarshal f, Unmarshal g, SymbolMatching f, SymbolMatching g) => Unmar
     else
       fail $ showFailure (Proxy @(f :+: g)) node
 
+instance Unmarshal t => Unmarshal (Rec1 t) where
+  unmarshalNode = fmap Rec1 . unmarshalNode
+
 
 class UnmarshalAnn a where
   unmarshalAnn

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DefaultSignatures, FlexibleContexts, FlexibleInstances,
-             PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, FlexibleContexts, FlexibleInstances, KindSignatures,
+             ScopedTypeVariables, TypeApplications, TypeOperators #-}
 module TreeSitter.Unmarshal
 ( parseByteString
 , FieldName(..)
@@ -177,7 +177,7 @@ instance UnmarshalField NonEmpty where
   unmarshalField [] = fail "expected a node but didn't get one"
 
 
-class SymbolMatching a where
+class SymbolMatching (a :: * -> *) where
   symbolMatch :: Proxy a -> Node -> Bool
 
   -- | Provide error message describing the node symbol vs. the symbols this can match

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -224,7 +224,11 @@ instance SymbolMatching a => SymbolMatching [a] where
   symbolMatch _ = symbolMatch (Proxy @a)
   showFailure _ = showFailure (Proxy @a)
 
-instance SymbolMatching k => SymbolMatching (M1 C c (M1 S s (K1 i k))) where
+instance SymbolMatching f => SymbolMatching (M1 i c f) where
+  symbolMatch _ = symbolMatch (Proxy @f)
+  showFailure _ = showFailure (Proxy @f)
+
+instance SymbolMatching k => SymbolMatching (K1 i k) where
   symbolMatch _ = symbolMatch (Proxy @k)
   showFailure _ = showFailure (Proxy @k)
 

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -84,6 +84,12 @@ instance UnmarshalAnn Text.Text where
     bytestring <- ask
     pure (decodeUtf8 (slice start end bytestring))
 
+-- | Instance for pairs of annotations
+instance (UnmarshalAnn a, UnmarshalAnn b) => UnmarshalAnn (a,b) where
+  unmarshalAnn node = (,)
+    <$> unmarshalAnn @a node
+    <*> unmarshalAnn @b node
+
 
 class UnmarshalField t where
   unmarshalField

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -78,6 +78,12 @@ class UnmarshalAnn a where
 instance UnmarshalAnn () where
   unmarshalAnn _ = pure ()
 
+instance UnmarshalAnn Text.Text where
+  unmarshalAnn node = do
+    Range start end <- unmarshalAnn node
+    bytestring <- ask
+    pure (decodeUtf8 (slice start end bytestring))
+
 
 class UnmarshalField t where
   unmarshalField

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -253,7 +253,7 @@ type Fields = Map.Map FieldName [Node]
 
 -- | Return the fields remaining in the current branch, represented as 'Map.Map' of 'FieldName's to their corresponding 'Node's.
 getFields :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m Fields
-getFields = go Map.empty -- >>= \fields -> liftIO (print (Map.keys fields)) >> pure fields
+getFields = go Map.empty
   where go fs = do
           node <- peekNode
           fieldName <- peekFieldName

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -74,6 +74,19 @@ class UnmarshalAnn a where
     => Node
     -> m a
 
+class UnmarshalField t where
+  unmarshalField
+    :: ( Carrier sig m
+       , Member (Reader ByteString) sig
+       , Member (Reader (Ptr Cursor)) sig
+       , MonadFail m
+       , MonadIO m
+       , Unmarshal f
+       , UnmarshalAnn a
+       )
+    => [Node]
+    -> m (t (f a))
+
 
 instance Unmarshal () where
   unmarshalNodes _ = pure ()

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -99,6 +99,13 @@ instance UnmarshalField [] where
     pure $ head' : tail'
   unmarshalField [] = pure []
 
+instance UnmarshalField NonEmpty where
+  unmarshalField (x:xs) = do
+    head' <- unmarshalNode x
+    tail' <- unmarshalField xs
+    pure $ head' :| tail'
+  unmarshalField [] = fail "expected a node but didn't get one"
+
 
 instance Unmarshal () where
   unmarshalNodes _ = pure ()

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -228,6 +228,10 @@ instance SymbolMatching f => SymbolMatching (M1 i c f) where
   symbolMatch _ = symbolMatch (Proxy @f)
   showFailure _ = showFailure (Proxy @f)
 
+instance SymbolMatching f => SymbolMatching (Rec1 f) where
+  symbolMatch _ = symbolMatch (Proxy @f)
+  showFailure _ = showFailure (Proxy @f)
+
 instance SymbolMatching k => SymbolMatching (K1 i k) where
   symbolMatch _ = symbolMatch (Proxy @k)
   showFailure _ = showFailure (Proxy @k)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -252,8 +252,11 @@ peekFieldName = do
   else
     Just . FieldName <$> liftIO (peekCString fieldName)
 
+
+type Fields = Map.Map FieldName [Node]
+
 -- | Return the fields remaining in the current branch, represented as 'Map.Map' of 'FieldName's to their corresponding 'Node's.
-getFields :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m (Map.Map FieldName [Node])
+getFields :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m Fields
 getFields = go Map.empty -- >>= \fields -> liftIO (print (Map.keys fields)) >> pure fields
   where go fs = do
           node <- peekNode
@@ -364,7 +367,7 @@ class GUnmarshalProduct f where
        , UnmarshalAnn a
        )
     => Node
-    -> Map.Map FieldName [Node]
+    -> Fields
     -> m (f a)
 
 -- Product structure

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -92,6 +92,13 @@ instance UnmarshalField Maybe where
   unmarshalField [x] = Just <$> unmarshalNode x
   unmarshalField _   = fail "expected a node of type ((f :+: g) a) but got multiple"
 
+instance UnmarshalField [] where
+  unmarshalField (x:xs) = do
+    head' <- unmarshalNode x
+    tail' <- unmarshalField xs
+    pure $ head' : tail'
+  unmarshalField [] = pure []
+
 
 instance Unmarshal () where
   unmarshalNodes _ = pure ()

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -191,10 +191,6 @@ instance SymbolMatching f => SymbolMatching (Rec1 f) where
   symbolMatch _ = symbolMatch (Proxy @f)
   showFailure _ = showFailure (Proxy @f)
 
-instance SymbolMatching k => SymbolMatching (K1 i k) where
-  symbolMatch _ = symbolMatch (Proxy @k)
-  showFailure _ = showFailure (Proxy @k)
-
 instance (SymbolMatching f, SymbolMatching g) => SymbolMatching (f :+: g) where
   symbolMatch _ = (||) <$> symbolMatch (Proxy @f) <*> symbolMatch (Proxy @g)
   showFailure _ = sep <$> showFailure (Proxy @f) <*> showFailure (Proxy @g)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -51,7 +51,7 @@ parseByteString language bytestring = withParser language $ \ parser -> withPars
       withCursor (castPtr rootPtr) $ \ cursor ->
         runM (runFail (runReader cursor (runReader bytestring (peekNode >>= maybe (fail "expected a root node") unmarshalNode))))
 
--- | Unmarshal is the process of iterating over tree-sitter’s parse trees using its tree cursor API and producing Haskell ASTs for the relevant nodes.
+-- | Unmarshalling is the process of iterating over tree-sitter’s parse trees using its tree cursor API and producing Haskell ASTs for the relevant nodes.
 --
 --   Datatypes which can be constructed from tree-sitter parse trees may use the default definition of 'unmarshalNode' providing that they have a suitable 'Generic' instance.
 class Unmarshal t where

--- a/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
@@ -9,7 +9,7 @@ import TreeSitter.Unmarshal
 data Expr a
   = IfExpr (If a)
   | BlockExpr (Block a)
-  | LitExpr (Lit a)
+  | VarExpr (Var a)
   | BinExpr (Bin a)
   deriving (Generic1, Unmarshal)
 
@@ -30,10 +30,10 @@ instance SymbolMatching Block where
   showFailure _ _ = ""
 
 -- | Leaf node.
-data Lit a = Lit { ann :: a, text :: Text.Text }
+data Var a = Var { ann :: a, text :: Text.Text }
   deriving (Generic1, Unmarshal)
 
-instance SymbolMatching Lit where
+instance SymbolMatching Var where
   symbolMatch _ _ = False
   showFailure _ _ = ""
 

--- a/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
@@ -2,7 +2,7 @@
 module TreeSitter.Unmarshal.Examples () where
 
 import qualified Data.Text as Text
-import GHC.Generics ((:+:), Generic)
+import GHC.Generics ((:+:), Generic1)
 import TreeSitter.Unmarshal
 
 -- | An example of a sum-of-products datatype.
@@ -11,52 +11,52 @@ data Expr a
   | BlockExpr (Block a)
   | LitExpr (Lit a)
   | BinExpr (Bin a)
-  deriving (Generic, Unmarshal)
+  deriving (Generic1, Unmarshal)
 
 -- | Product with multiple fields.
 data If a = If { ann :: a, condition :: Expr a, consequence :: Expr a, alternative :: Maybe (Expr a) }
-  deriving (Generic, Unmarshal)
+  deriving (Generic1, Unmarshal)
 
-instance SymbolMatching (If a) where
+instance SymbolMatching If where
   symbolMatch _ _ = False
   showFailure _ _ = ""
 
 -- | Single-field product.
 data Block a = Block { ann :: a, body :: [Expr a] }
-  deriving (Generic, Unmarshal)
+  deriving (Generic1, Unmarshal)
 
-instance SymbolMatching (Block a) where
+instance SymbolMatching Block where
   symbolMatch _ _ = False
   showFailure _ _ = ""
 
 -- | Leaf node.
 data Lit a = Lit { ann :: a, text :: Text.Text }
-  deriving (Generic, Unmarshal)
+  deriving (Generic1, Unmarshal)
 
-instance SymbolMatching (Lit a) where
+instance SymbolMatching Lit where
   symbolMatch _ _ = False
   showFailure _ _ = ""
 
 -- | Product with anonymous sum field.
 data Bin a = Bin { ann :: a, lhs :: Expr a, op :: (AnonPlus :+: AnonTimes) a, rhs :: Expr a }
-  deriving (Generic, Unmarshal)
+  deriving (Generic1, Unmarshal)
 
-instance SymbolMatching (Bin a) where
+instance SymbolMatching Bin where
   symbolMatch _ _ = False
   showFailure _ _ = ""
 
 -- | Anonymous leaf node.
 newtype AnonPlus a = AnonPlus { ann :: a }
-  deriving (Generic, Unmarshal)
+  deriving (Generic1, Unmarshal)
 
-instance SymbolMatching (AnonPlus a) where
+instance SymbolMatching AnonPlus where
   symbolMatch _ _ = False
   showFailure _ _ = ""
 
 -- | Anonymous leaf node.
 newtype AnonTimes a = AnonTimes { ann :: a }
-  deriving (Generic, Unmarshal)
+  deriving (Generic1, Unmarshal)
 
-instance SymbolMatching (AnonTimes a) where
+instance SymbolMatching AnonTimes where
   symbolMatch _ _ = False
   showFailure _ _ = ""


### PR DESCRIPTION
This changes `Unmarshal` to operate on type constructors of kind * -> * instead of types of kind *, allowing us a great deal more latitude in separating out the various roles types play in our ASTs. This was made possible by @aymannadeem’s work in #214, and results in a substantial simplification to the implementation, which just goes to show what you can accomplish with parametricity.

- [x] Depends on #221.
- [x] Fixes #219.