### PR TITLE
Common representation for anonymous (token) AST nodes

### DIFF
--- a/tree-sitter-python/TreeSitter/Python/AST.hs
+++ b/tree-sitter-python/TreeSitter/Python/AST.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric, DeriveTraversable, DuplicateRecordFields, TemplateHaskell, TypeApplications #-}
+{-# LANGUAGE DataKinds, DeriveAnyClass, DeriveGeneric, DeriveTraversable, DuplicateRecordFields, TemplateHaskell, TypeApplications #-}
 module TreeSitter.Python.AST where
 
 import TreeSitter.GenerateSyntax

--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -28,7 +28,7 @@ s `shouldParseInto` t = do
 
 pass = Py.PassStatementSimpleStatement (Py.PassStatement () "pass" )
 one = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.IntegerPrimaryExpression (Py.Integer () "1")))])
-plusOne = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.UnaryOperatorPrimaryExpression (Py.UnaryOperator () (L1 (Token () :: Py.AnonymousPlus ())) (Py.IntegerPrimaryExpression (Py.Integer () "1")))))])
+plusOne = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.UnaryOperatorPrimaryExpression (Py.UnaryOperator () (L1 (Token ())) (Py.IntegerPrimaryExpression (Py.Integer () "1")))))])
 function = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier () "expensive")))])
 
 prop_simpleExamples :: Property

--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -15,6 +15,7 @@ import qualified Hedgehog.Range as Range
 import           System.Exit (exitFailure, exitSuccess)
 import           TreeSitter.Python
 import qualified TreeSitter.Python.AST as Py
+import           TreeSitter.Token
 import           TreeSitter.Unmarshal
 import           GHC.Generics
 
@@ -27,6 +28,7 @@ s `shouldParseInto` t = do
 
 pass = Py.PassStatementSimpleStatement (Py.PassStatement () "pass" )
 one = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.IntegerPrimaryExpression (Py.Integer () "1")))])
+plusOne = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.UnaryOperatorPrimaryExpression (Py.UnaryOperator () (L1 (Token () :: Py.AnonymousPlus ())) (Py.IntegerPrimaryExpression (Py.Integer () "1")))))])
 function = Py.ExpressionStatementSimpleStatement (Py.ExpressionStatement () [L1 (Py.PrimaryExpressionExpression (Py.IdentifierPrimaryExpression (Py.Identifier () "expensive")))])
 
 prop_simpleExamples :: Property
@@ -35,6 +37,7 @@ prop_simpleExamples = property $ do
   "# bah" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [] }
   "pass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 pass] }
   "1" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 one] }
+  "+1" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 plusOne] }
   "expensive" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 function] }
   "1\npass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 one, R1 pass] }
 

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -63,12 +63,10 @@ syntaxDatatype language datatype = do
     LeafType (DatatypeName datatypeName) Anonymous -> do
       tsSymbol <- runIO $ withCString datatypeName (TS.ts_language_symbol_for_name language)
       pure [ TySynD name [] (ConT ''Token `AppT` LitT (StrTyLit datatypeName) `AppT` LitT (NumTyLit (fromIntegral tsSymbol))) ]
-    LeafType (DatatypeName datatypeName) named -> do
-      con <- ctorForLeafType named (DatatypeName datatypeName) typeParameterName
+    LeafType (DatatypeName datatypeName) Named -> do
+      con <- ctorForLeafType Named (DatatypeName datatypeName) typeParameterName
       result <- symbolMatchingInstance language name datatypeName
-      pure $ case named of
-        Anonymous -> NewtypeD [] name [PlainTV typeParameterName] Nothing con deriveClause:result
-        Named -> generatedDatatype name [con] typeParameterName:result
+      pure $ generatedDatatype name [con] typeParameterName:result
   where
     name = toName (datatypeNameStatus datatype) (getDatatypeName (TreeSitter.Deserialize.datatypeName datatype))
     deriveClause = [ DerivClause Nothing [ ConT ''TS.Unmarshal, ConT ''Eq, ConT ''Ord, ConT ''Show, ConT ''Generic, ConT ''Foldable, ConT ''Functor, ConT ''Traversable, ConT ''Generic1] ]

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -100,7 +100,7 @@ constructorForSumChoice str typeParameterName (MkType (DatatypeName n) named) = 
 
 -- | Build Q Constructor for product types (nodes with fields)
 ctorForProductType :: String -> Name -> Maybe Children -> [(String, Field)] -> Q Con
-ctorForProductType constructorName typeParameterName children fields = ctorForTypes Named constructorName lists where
+ctorForProductType constructorName typeParameterName children fields = ctorForTypes constructorName lists where
   lists = annotation : fieldList ++ childList
   annotation = ("ann", varT typeParameterName)
   fieldList = map (fmap toType) fields
@@ -116,14 +116,14 @@ ctorForProductType constructorName typeParameterName children fields = ctorForTy
 
 -- | Build Q Constructor for leaf types (nodes with no fields or subtypes)
 ctorForLeafType :: DatatypeName -> Name -> Q Con
-ctorForLeafType (DatatypeName name) typeParameterName = ctorForTypes Named name
+ctorForLeafType (DatatypeName name) typeParameterName = ctorForTypes name
   [ ("ann",   varT typeParameterName) -- ann :: a
   , ("bytes", conT ''Text)
   ]
 
 -- | Build Q Constructor for records
-ctorForTypes :: Named -> String -> [(String, Q TH.Type)] -> Q Con
-ctorForTypes named constructorName types = recC (toName named constructorName) recordFields where
+ctorForTypes :: String -> [(String, Q TH.Type)] -> Q Con
+ctorForTypes constructorName types = recC (toName Named constructorName) recordFields where
   recordFields = map (uncurry toVarBangType) types
   toVarBangType str type' = TH.varBangType (mkName . addTickIfNecessary . removeUnderscore $ str) (TH.bangType strictness type')
 

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -32,6 +32,7 @@ import Data.Aeson hiding (String)
 import System.Directory
 import System.FilePath.Posix
 import TreeSitter.Node
+import TreeSitter.Token
 import TreeSitter.Symbol (escapeOperatorPunctuation)
 
 
@@ -59,6 +60,9 @@ syntaxDatatype language datatype = do
       con <- ctorForProductType datatypeName typeParameterName children fields
       result <- symbolMatchingInstance language name datatypeName
       pure $ generatedDatatype name [con] typeParameterName:result
+    LeafType (DatatypeName datatypeName) Anonymous -> do
+      tsSymbol <- runIO $ withCString datatypeName (TS.ts_language_symbol_for_name language)
+      pure [ TySynD name [] (ConT ''Token `AppT` LitT (StrTyLit datatypeName) `AppT` LitT (NumTyLit (fromIntegral tsSymbol))) ]
     LeafType (DatatypeName datatypeName) named -> do
       con <- ctorForLeafType named (DatatypeName datatypeName) typeParameterName
       result <- symbolMatchingInstance language name datatypeName

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -19,6 +19,14 @@ fromTSSymbol symbol
   | otherwise                             = toEnum (fromIntegral symbol)
   where err = parseErrorSymbol
 
+-- | Map a value of a 'Symbol' datatype to the corresponding 'TSSymbol'.
+--
+--   This should be used instead of 'fromEnum' to perform this conversion, because tree-sitter represents parse errors with the unsigned short @65535@, which is generally not contiguous with the other symbols.
+toTSSymbol :: Symbol symbol => symbol -> TSSymbol
+toTSSymbol symbol
+  | symbol == parseErrorSymbol = maxBound
+  | otherwise                  = fromIntegral (fromEnum symbol)
+
 -- | The value of a 'Symbol' datatype representing parse errors.
 parseErrorSymbol :: Symbol symbol => symbol
 parseErrorSymbol = maxBound

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -19,14 +19,6 @@ fromTSSymbol symbol
   | otherwise                             = toEnum (fromIntegral symbol)
   where err = parseErrorSymbol
 
--- | Map a value of a 'Symbol' datatype to the corresponding 'TSSymbol'.
---
---   This should be used instead of 'fromEnum' to perform this conversion, because tree-sitter represents parse errors with the unsigned short @65535@, which is generally not contiguous with the other symbols.
-toTSSymbol :: Symbol symbol => symbol -> TSSymbol
-toTSSymbol symbol
-  | symbol == parseErrorSymbol = maxBound
-  | otherwise                  = fromIntegral (fromEnum symbol)
-
 -- | The value of a 'Symbol' datatype representing parse errors.
 parseErrorSymbol :: Symbol symbol => symbol
 parseErrorSymbol = maxBound

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveLift, LambdaCase #-}
+{-# LANGUAGE DeriveLift, ScopedTypeVariables, LambdaCase #-}
 module TreeSitter.Symbol where
 
 import Data.Char (isAlpha, toUpper, isControl)
@@ -13,11 +13,8 @@ type TSSymbol = Word16
 -- | Map a 'TSSymbol' to the corresponding value of a 'Symbol' datatype.
 --
 --   This should be used instead of 'toEnum' to perform this conversion, because tree-sitter represents parse errors with the unsigned short @65535@, which is generally not contiguous with the other symbols.
-fromTSSymbol :: Symbol symbol => TSSymbol -> symbol
-fromTSSymbol symbol
-  | symbol >= fromIntegral (fromEnum err) = err
-  | otherwise                             = toEnum (fromIntegral symbol)
-  where err = parseErrorSymbol
+fromTSSymbol :: forall symbol . Symbol symbol => TSSymbol -> symbol
+fromTSSymbol symbol = toEnum (min (fromIntegral symbol) (fromEnum (maxBound :: symbol)))
 
 -- | The value of a 'Symbol' datatype representing parse errors.
 parseErrorSymbol :: Symbol symbol => symbol

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -16,10 +16,6 @@ type TSSymbol = Word16
 fromTSSymbol :: forall symbol . Symbol symbol => TSSymbol -> symbol
 fromTSSymbol symbol = toEnum (min (fromIntegral symbol) (fromEnum (maxBound :: symbol)))
 
--- | The value of a 'Symbol' datatype representing parse errors.
-parseErrorSymbol :: Symbol symbol => symbol
-parseErrorSymbol = maxBound
-
 
 data SymbolType = Regular | Anonymous | Auxiliary
   deriving (Enum, Eq, Lift, Ord, Show)

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveLift, ScopedTypeVariables, LambdaCase #-}
+{-# LANGUAGE DeriveLift, LambdaCase #-}
 module TreeSitter.Symbol where
 
 import Data.Char (isAlpha, toUpper, isControl)
@@ -13,8 +13,11 @@ type TSSymbol = Word16
 -- | Map a 'TSSymbol' to the corresponding value of a 'Symbol' datatype.
 --
 --   This should be used instead of 'toEnum' to perform this conversion, because tree-sitter represents parse errors with the unsigned short @65535@, which is generally not contiguous with the other symbols.
-fromTSSymbol :: forall symbol . Symbol symbol => TSSymbol -> symbol
-fromTSSymbol symbol = toEnum (min (fromIntegral symbol) (fromEnum (maxBound :: symbol)))
+fromTSSymbol :: Symbol symbol => TSSymbol -> symbol
+fromTSSymbol symbol
+  | symbol >= fromIntegral (fromEnum err) = err
+  | otherwise                             = toEnum (fromIntegral symbol)
+  where err = parseErrorSymbol
 
 -- | The value of a 'Symbol' datatype representing parse errors.
 parseErrorSymbol :: Symbol symbol => symbol

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -16,6 +16,10 @@ type TSSymbol = Word16
 fromTSSymbol :: forall symbol . Symbol symbol => TSSymbol -> symbol
 fromTSSymbol symbol = toEnum (min (fromIntegral symbol) (fromEnum (maxBound :: symbol)))
 
+-- | The value of a 'Symbol' datatype representing parse errors.
+parseErrorSymbol :: Symbol symbol => symbol
+parseErrorSymbol = maxBound
+
 
 data SymbolType = Regular | Anonymous | Auxiliary
   deriving (Enum, Eq, Lift, Ord, Show)

--- a/tree-sitter/src/TreeSitter/Token.hs
+++ b/tree-sitter/src/TreeSitter/Token.hs
@@ -6,5 +6,12 @@ module TreeSitter.Token
 import GHC.Generics (Generic, Generic1)
 import GHC.TypeLits (Symbol, Nat)
 
+-- | An AST node representing a token, indexed by its name and numeric value.
+--
+-- For convenience, token types are typically used via type synonyms, e.g.:
+--
+-- @
+-- type AnonymousPlus = Token "+" 123
+-- @
 newtype Token (symName :: Symbol) (symVal :: Nat) a = Token { ann :: a }
   deriving (Eq, Foldable, Functor, Generic, Generic1, Ord, Show, Traversable)

--- a/tree-sitter/src/TreeSitter/Token.hs
+++ b/tree-sitter/src/TreeSitter/Token.hs
@@ -1,0 +1,2 @@
+module TreeSitter.Token
+() where

--- a/tree-sitter/src/TreeSitter/Token.hs
+++ b/tree-sitter/src/TreeSitter/Token.hs
@@ -1,2 +1,5 @@
 module TreeSitter.Token
-() where
+( Token(..)
+) where
+
+newtype Token sym a = Token { ann :: a }

--- a/tree-sitter/src/TreeSitter/Token.hs
+++ b/tree-sitter/src/TreeSitter/Token.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, PolyKinds #-}
+{-# LANGUAGE DataKinds, DeriveGeneric, DeriveTraversable, KindSignatures #-}
 module TreeSitter.Token
 ( Token(..)
 ) where
 
 import GHC.Generics (Generic, Generic1)
+import GHC.TypeLits (Symbol, Nat)
 
-newtype Token symName symVal a = Token { ann :: a }
+newtype Token (symName :: Symbol) (symVal :: Nat) a = Token { ann :: a }
   deriving (Eq, Foldable, Functor, Generic, Generic1, Ord, Show, Traversable)

--- a/tree-sitter/src/TreeSitter/Token.hs
+++ b/tree-sitter/src/TreeSitter/Token.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE DeriveGeneric, DeriveTraversable #-}
 module TreeSitter.Token
 ( Token(..)
 ) where
 
+import GHC.Generics (Generic, Generic1)
+
 newtype Token sym a = Token { ann :: a }
+  deriving (Eq, Foldable, Functor, Generic, Generic1, Ord, Show, Traversable)

--- a/tree-sitter/src/TreeSitter/Token.hs
+++ b/tree-sitter/src/TreeSitter/Token.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, PolyKinds #-}
 module TreeSitter.Token
 ( Token(..)
 ) where

--- a/tree-sitter/src/TreeSitter/Token.hs
+++ b/tree-sitter/src/TreeSitter/Token.hs
@@ -5,5 +5,5 @@ module TreeSitter.Token
 
 import GHC.Generics (Generic, Generic1)
 
-newtype Token sym a = Token { ann :: a }
+newtype Token symName symVal a = Token { ann :: a }
   deriving (Eq, Foldable, Functor, Generic, Generic1, Ord, Show, Traversable)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -99,7 +99,7 @@ instance (Unmarshal f, Unmarshal g, SymbolMatching f, SymbolMatching g) => Unmar
 instance Unmarshal t => Unmarshal (Rec1 t) where
   unmarshalNode = fmap Rec1 . unmarshalNode
 
-instance Unmarshal (Token sym) where
+instance Unmarshal (Token sym n) where
   unmarshalNode = fmap Token . unmarshalAnn
 
 
@@ -201,7 +201,7 @@ instance SymbolMatching f => SymbolMatching (Rec1 f) where
   symbolMatch _ = symbolMatch (Proxy @f)
   showFailure _ = showFailure (Proxy @f)
 
-instance KnownSymbol sym => SymbolMatching (Token sym) where
+instance KnownSymbol sym => SymbolMatching (Token sym n) where
   -- FIXME: this should compare the node’s symbol against @sym@
   symbolMatch _ _ = False
   showFailure _ _ = "expected " ++ symbolVal (Proxy @sym)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -36,6 +36,7 @@ import           TreeSitter.Language as TS
 import           TreeSitter.Node as TS
 import           TreeSitter.Parser as TS
 import           TreeSitter.Tree as TS
+import           TreeSitter.Token as TS
 import           Source.Loc
 import           Source.Span
 import           Data.Proxy
@@ -96,6 +97,9 @@ instance (Unmarshal f, Unmarshal g, SymbolMatching f, SymbolMatching g) => Unmar
 
 instance Unmarshal t => Unmarshal (Rec1 t) where
   unmarshalNode = fmap Rec1 . unmarshalNode
+
+instance Unmarshal (Token sym) where
+  unmarshalNode = fmap Token . unmarshalAnn
 
 
 -- | Unmarshal an annotation field.

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -202,6 +202,7 @@ instance SymbolMatching f => SymbolMatching (Rec1 f) where
   showFailure _ = showFailure (Proxy @f)
 
 instance KnownSymbol sym => SymbolMatching (Token sym) where
+  -- FIXME: this should compare the node’s symbol against @sym@
   symbolMatch _ _ = False
   showFailure _ _ = "expected " ++ symbolVal (Proxy @sym)
 

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -201,9 +201,8 @@ instance SymbolMatching f => SymbolMatching (Rec1 f) where
   symbolMatch _ = symbolMatch (Proxy @f)
   showFailure _ = showFailure (Proxy @f)
 
-instance KnownSymbol sym => SymbolMatching (Token sym n) where
-  -- FIXME: this should compare the node’s symbol against @sym@
-  symbolMatch _ _ = False
+instance (KnownNat n, KnownSymbol sym) => SymbolMatching (Token sym n) where
+  symbolMatch _ node = nodeSymbol node == fromIntegral (natVal (Proxy @n))
   showFailure _ _ = "expected " ++ symbolVal (Proxy @sym)
 
 instance (SymbolMatching f, SymbolMatching g) => SymbolMatching (f :+: g) where

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -31,6 +31,7 @@ import           Foreign.Marshal.Utils
 import           Foreign.Ptr
 import           Foreign.Storable
 import           GHC.Generics
+import           GHC.TypeLits
 import           TreeSitter.Cursor as TS
 import           TreeSitter.Language as TS
 import           TreeSitter.Node as TS
@@ -199,6 +200,10 @@ instance SymbolMatching f => SymbolMatching (M1 i c f) where
 instance SymbolMatching f => SymbolMatching (Rec1 f) where
   symbolMatch _ = symbolMatch (Proxy @f)
   showFailure _ = showFailure (Proxy @f)
+
+instance KnownSymbol sym => SymbolMatching (Token sym) where
+  symbolMatch _ _ = False
+  showFailure _ _ = "expected " ++ symbolVal (Proxy @sym)
 
 instance (SymbolMatching f, SymbolMatching g) => SymbolMatching (f :+: g) where
   symbolMatch _ = (||) <$> symbolMatch (Proxy @f) <*> symbolMatch (Proxy @g)

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, FlexibleContexts, FlexibleInstances, KindSignatures,
+{-# LANGUAGE DefaultSignatures, FlexibleContexts, FlexibleInstances, PolyKinds,
              ScopedTypeVariables, TypeApplications, TypeOperators #-}
 module TreeSitter.Unmarshal
 ( parseByteString

--- a/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric, DuplicateRecordFields, TypeOperators #-}
+{-# LANGUAGE DataKinds, DeriveAnyClass, DeriveGeneric, DuplicateRecordFields, TypeOperators #-}
 module TreeSitter.Unmarshal.Examples () where
 
 import Control.Effect.Reader
@@ -10,6 +10,7 @@ import GHC.Generics ((:+:), Generic1)
 import Numeric (readDec)
 import Prelude hiding (fail)
 import Source.Range
+import TreeSitter.Token
 import TreeSitter.Unmarshal
 
 -- | An example of a sum-of-products datatype.
@@ -62,20 +63,10 @@ instance SymbolMatching Bin where
   showFailure _ _ = ""
 
 -- | Anonymous leaf node.
-newtype AnonPlus a = AnonPlus { ann :: a }
-  deriving (Generic1, Unmarshal)
-
-instance SymbolMatching AnonPlus where
-  symbolMatch _ _ = False
-  showFailure _ _ = ""
+type AnonPlus = Token "+"
 
 -- | Anonymous leaf node.
-newtype AnonTimes a = AnonTimes { ann :: a }
-  deriving (Generic1, Unmarshal)
-
-instance SymbolMatching AnonTimes where
-  symbolMatch _ _ = False
-  showFailure _ _ = ""
+type AnonTimes = Token "*"
 
 
 newtype IntegerLit = IntegerLit Integer

--- a/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal/Examples.hs
@@ -63,10 +63,10 @@ instance SymbolMatching Bin where
   showFailure _ _ = ""
 
 -- | Anonymous leaf node.
-type AnonPlus = Token "+"
+type AnonPlus = Token "+" 0
 
 -- | Anonymous leaf node.
-type AnonTimes = Token "*"
+type AnonTimes = Token "*" 1
 
 
 newtype IntegerLit = IntegerLit Integer

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -47,6 +47,7 @@ library
                      , TreeSitter.GenerateSyntax
                      , TreeSitter.Deserialize
                      , TreeSitter.Cursor
+                     , TreeSitter.Token
   other-modules:       TreeSitter.Unmarshal.Examples
   include-dirs:        vendor/tree-sitter/lib/include
                      , vendor/tree-sitter/lib/src


### PR DESCRIPTION
This PR replaces the `NewtypeD` we generated for anonymous leaf types with a type synonym for a common `Token` type, indexed by both the symbol name and value for the grammar rule it corresponds to.

This allows us to avoid deriving a _lot_ of instances, and thus improve compile times for the AST modules by a decent margin.

Fixes #139.