### PR TITLE
ghc 8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
   include:
     - compiler: "ghc-8.6.5"
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
-    # - compiler: "ghc-8.8.1"
-    #   addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.8.1"
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
 
 before_install:
 - mkdir -p $HOME/.local/bin

--- a/tree-sitter-go/tree-sitter-go.cabal
+++ b/tree-sitter-go/tree-sitter-go.cabal
@@ -11,20 +11,38 @@ copyright:           2017 GitHub
 category:            Tree-sitter, Go
 build-type:          Simple
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.Go
   build-depends:       base              >= 4.12 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-go-internal
-  default-language:    Haskell2010
 
 library tree-sitter-go-internal
+  import: common
   exposed-modules:     TreeSitter.Go.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   include-dirs:        vendor/tree-sitter-go/src
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-go/src/parser.c

--- a/tree-sitter-haskell/tree-sitter-haskell.cabal
+++ b/tree-sitter-haskell/tree-sitter-haskell.cabal
@@ -11,37 +11,54 @@ copyright:           2017 GitHub
 category:            Tree-sitter, Haskell
 build-type:          Simple
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 flag build-examples
   description: Build tree-sitter-haskell examples.
   default:     False
 
 executable demo
+  import: common
   main-is: Demo.hs
   if !flag(build-examples)
     buildable: False
-  hs-source-dirs:
-      examples
+  hs-source-dirs: examples
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base
     , tree-sitter
     , tree-sitter-haskell
-  default-language: Haskell2010
 
 library
+  import: common
   exposed-modules:     TreeSitter.Haskell
   build-depends:       base              >= 4.12 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-haskell-internal
-  default-language:    Haskell2010
 
 library tree-sitter-haskell-internal
+  import: common
   exposed-modules:     TreeSitter.Haskell.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   Include-dirs:        vendor/tree-sitter-haskell/src
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-haskell/src/parser.c

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -14,7 +14,7 @@ data-files:          vendor/tree-sitter-java/src/node-types.json
 extra-source-files:  ChangeLog.md
 
 common common
-  default-language:    Haskell2010
+  default-language: Haskell2010
   ghc-options:
     -Weverything
     -Wno-all-missed-specialisations
@@ -27,7 +27,9 @@ common common
     -Wno-safe
     -Wno-unsafe
   if (impl(ghc >= 8.6))
-    ghc-options:       -Wno-star-is-type
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
 
 library
   import: common

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -11,20 +11,38 @@ copyright:           2017 GitHub
 category:            Tree-sitter, JSON
 build-type:          Simple
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.JSON
   build-depends:       base              >= 4.12 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-json-internal
-  default-language:    Haskell2010
 
 library tree-sitter-json-internal
+  import: common
   exposed-modules:     TreeSitter.JSON.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   include-dirs:        vendor/tree-sitter-json/src
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-json/src/parser.c

--- a/tree-sitter-nix/tree-sitter-nix.cabal
+++ b/tree-sitter-nix/tree-sitter-nix.cabal
@@ -12,20 +12,38 @@ category:            Web
 build-type:          Simple
 -- extra-source-files:
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.Nix
   build-depends:       base              >= 4.7 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-nix-internal
-  default-language:    Haskell2010
 
 library tree-sitter-nix-internal
+  import: common
   exposed-modules:     TreeSitter.Nix.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   Include-dirs:        vendor/tree-sitter-nix/src
   c-sources:           vendor/tree-sitter-nix/src/parser.c
                        vendor/tree-sitter-nix/src/scanner.cc

--- a/tree-sitter-php/tree-sitter-php.cabal
+++ b/tree-sitter-php/tree-sitter-php.cabal
@@ -11,20 +11,38 @@ copyright:           2017 GitHub
 category:            Tree-sitter, PHP
 build-type:          Simple
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.PHP
   build-depends:       base              >= 4.12 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-php-internal
-  default-language:    Haskell2010
 
 library tree-sitter-php-internal
+  import: common
   exposed-modules:     TreeSitter.PHP.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   include-dirs:        vendor/tree-sitter-php/src
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-php/src/parser.c

--- a/tree-sitter-python/TreeSitter/Python/AST.hs
+++ b/tree-sitter-python/TreeSitter/Python/AST.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds, DeriveAnyClass, DeriveGeneric, DeriveTraversable, DuplicateRecordFields, TemplateHaskell, TypeApplications #-}
-module TreeSitter.Python.AST where
+module TreeSitter.Python.AST
+( module TreeSitter.Python.AST
+) where
 
 import TreeSitter.GenerateSyntax
 import Prelude hiding (True, False, Float, Integer, String)

--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -1,18 +1,12 @@
 {-# LANGUAGE DisambiguateRecordFields, OverloadedStrings, OverloadedLists, TemplateHaskell #-}
 module Main (main) where
 
-import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Bool (bool)
 import           Data.ByteString (ByteString)
-import           Data.Char
-import           Data.Foldable
 import           GHC.Generics
 import           Hedgehog
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
 import           System.Exit (exitFailure, exitSuccess)
-import           TreeSitter.GenerateSyntax
 import           TreeSitter.Python
 import qualified TreeSitter.Python.AST as Py
 import           TreeSitter.Token
@@ -40,6 +34,5 @@ prop_simpleExamples = property $ do
   "expensive" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 function] }
   "1\npass" `shouldParseInto` Py.Module { Py.ann = (), Py.extraChildren = [R1 one, R1 pass] }
 
-
-
+main :: IO ()
 main = checkParallel $$(discover) >>= bool exitFailure exitSuccess

--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DisambiguateRecordFields, OverloadedStrings, OverloadedLists, TemplateHaskell #-}
-
-module Main where
+module Main (main) where
 
 import           TreeSitter.GenerateSyntax
 import           Control.Monad

--- a/tree-sitter-python/test/Main.hs
+++ b/tree-sitter-python/test/Main.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE DisambiguateRecordFields, OverloadedStrings, OverloadedLists, TemplateHaskell #-}
 module Main (main) where
 
-import           TreeSitter.GenerateSyntax
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Bool (bool)
 import           Data.ByteString (ByteString)
 import           Data.Char
 import           Data.Foldable
+import           GHC.Generics
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           System.Exit (exitFailure, exitSuccess)
+import           TreeSitter.GenerateSyntax
 import           TreeSitter.Python
 import qualified TreeSitter.Python.AST as Py
 import           TreeSitter.Token
 import           TreeSitter.Unmarshal
-import           GHC.Generics
 
 -- TODO: add tests that verify correctness for product, sum and leaf types
 

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -45,6 +45,7 @@ library
                      , tree-sitter-python-internal
 
 library tree-sitter-python-internal
+  import: common
   exposed-modules:     TreeSitter.Python.Internal
   hs-source-dirs:      internal
   build-depends:       base

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -13,7 +13,26 @@ build-type:          Simple
 data-files:          vendor/tree-sitter-python/src/node-types.json
 extra-source-files:  ChangeLog.md
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.Python
                      , TreeSitter.Python.AST
   build-depends:       base              >= 4.12 && < 5
@@ -24,31 +43,23 @@ library
                      , semantic-source  ^>= 0
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-python-internal
-  default-language:    Haskell2010
-  ghc-options:         -Weverything -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-name-shadowing -Wno-monomorphism-restriction -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-missing-export-lists
-  if (impl(ghc >= 8.6))
-    ghc-options:       -Wno-star-is-type
 
 library tree-sitter-python-internal
   exposed-modules:     TreeSitter.Python.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   Include-dirs:        vendor/tree-sitter-python/src
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-python/src/parser.c
                      , vendor/tree-sitter-python/src/scanner.cc
   extra-libraries:     stdc++
-  ghc-options:         -Weverything -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-name-shadowing -Wno-monomorphism-restriction -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-missing-export-lists
-  if (impl(ghc >= 8.6))
-    ghc-options:       -Wno-star-is-type
 
 test-suite test
+  import: common
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Main.hs
-  default-language: Haskell2010
   build-depends:    base
                   , tree-sitter
                   , tree-sitter-python

--- a/tree-sitter-ruby/tree-sitter-ruby.cabal
+++ b/tree-sitter-ruby/tree-sitter-ruby.cabal
@@ -11,20 +11,38 @@ copyright:           2017 GitHub
 category:            Tree-sitter, Ruby
 build-type:          Simple
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.Ruby
   build-depends:       base              >= 4.12 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-ruby-internal
-  default-language:    Haskell2010
 
 library tree-sitter-ruby-internal
+  import: common
   exposed-modules:     TreeSitter.Ruby.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   Include-dirs:        vendor/tree-sitter-ruby/src
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-ruby/src/parser.c

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -11,20 +11,38 @@ copyright:           2017 GitHub
 category:            Tree-sitter, TypeScript
 build-type:          Simple
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.TSX
   build-depends:       base              >= 4.12 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-tsx-internal
-  default-language:    Haskell2010
 
 library tree-sitter-tsx-internal
+  import: common
   exposed-modules:     TreeSitter.TSX.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   Include-dirs:        vendor/tree-sitter-typescript/tsx/src
                        vendor/tree-sitter-typescript/common
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-typescript/tree-sitter-typescript.cabal
+++ b/tree-sitter-typescript/tree-sitter-typescript.cabal
@@ -11,20 +11,38 @@ copyright:           2017 GitHub
 category:            Tree-sitter, TypeScript
 build-type:          Simple
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   exposed-modules:     TreeSitter.TypeScript
   build-depends:       base              >= 4.12 && < 5
                      , tree-sitter       >= 0.3 && < 1
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-typescript-internal
-  default-language:    Haskell2010
 
 library tree-sitter-typescript-internal
+  import: common
   exposed-modules:     TreeSitter.TypeScript.Internal
   hs-source-dirs:      internal
   build-depends:       base
                      , tree-sitter
-  default-language:    Haskell2010
   include-dirs:        vendor/tree-sitter-typescript/typescript/src
                        vendor/tree-sitter-typescript/common
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter/src/TreeSitter/Deserialize.hs
+++ b/tree-sitter/src/TreeSitter/Deserialize.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
+-- Turn off partial field warnings for Datatype.
+{-# OPTIONS_GHC -Wno-partial-fields #-}
 module TreeSitter.Deserialize
 ( Datatype (..)
 , Field (..)

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -1,5 +1,11 @@
 {-# LANGUAGE DeriveLift, ScopedTypeVariables, LambdaCase #-}
-module TreeSitter.Symbol where
+module TreeSitter.Symbol
+( TSSymbol
+, fromTSSymbol
+, Symbol(..)
+, symbolToName
+, escapeOperatorPunctuation
+) where
 
 import Data.Char (isAlpha, toUpper, isControl)
 import Data.Function ((&))

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -2,6 +2,7 @@
 module TreeSitter.Symbol
 ( TSSymbol
 , fromTSSymbol
+, SymbolType(..)
 , Symbol(..)
 , symbolToName
 , escapeOperatorPunctuation

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -319,7 +319,7 @@ instance UnmarshalAnn k => GUnmarshal (K1 c k) where
 instance GUnmarshal Par1 where
   gunmarshalNode node = Par1 <$> unmarshalAnn node
 
-instance (Unmarshal t, SymbolMatching t) => GUnmarshal (Rec1 t) where
+instance Unmarshal t => GUnmarshal (Rec1 t) where
   gunmarshalNode node = Rec1 <$> unmarshalNode node
 
 -- For product datatypes:

--- a/tree-sitter/test-codegen/test-codegen.hs
+++ b/tree-sitter/test-codegen/test-codegen.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TemplateHaskell, TypeApplications #-}
-
-module Main where
+module Main (main) where
 
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -38,8 +37,8 @@ initialCaps = Gen.frequency
 
 prop_initUpper :: Property
 prop_initUpper = property $ do
-  (x:xs) <- forAll (Gen.string (Range.constant 1 5) initialCaps)
-  (y:ys) <- pure $ initUpper (x:xs)
+  x:xs <- forAll (Gen.string (Range.constant 1 5) initialCaps)
+  y:_  <- pure $ initUpper (x:xs)
   when (isLower x) (assert (isUpper y))
 
 prop_escapePunct :: Property

--- a/tree-sitter/test/Spec.hs
+++ b/tree-sitter/test/Spec.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE TemplateHaskell #-}
-module Main where
+module Main (main) where
 
 import Data.Bool (bool)
 import Control.Monad.IO.Class
 import Foreign
 import Foreign.C.Types
-import Foreign.Storable
 import Hedgehog
 import System.Exit (exitFailure, exitSuccess)
 import TreeSitter.Cursor
@@ -45,6 +44,7 @@ prop_Parser_timeout = property $ do
   timeout === 1000
   liftIO (ts_parser_delete parser)
 
+main :: IO ()
 main = checkSequential $$(discover) >>= bool exitFailure exitSuccess
 
 foreign import ccall unsafe "src/bridge.c sizeof_tsnode" sizeof_tsnode :: CSize

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.2
+cabal-version:       2.4
 name:                tree-sitter
 version:             0.4.0.0
 synopsis:            Unstable bindings for the tree-sitter parsing library.
@@ -26,7 +26,26 @@ extra-source-files:  vendor/tree-sitter/lib/src/*.c
                    , vendor/tree-sitter/lib/utf8proc/utf8proc_data.c
                    , ChangeLog.md
 
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
 library
+  import: common
   hs-source-dirs:      src
   build-depends:       base                  >= 4.12 && < 5
                      , aeson                ^>= 1.4.2
@@ -41,7 +60,6 @@ library
                      , unordered-containers ^>= 0.2.9
                      , containers            >= 0.6.0.1
                      , semantic-source      ^>= 0.0.0.0
-  default-language:    Haskell2010
   exposed-modules:     TreeSitter.Parser
                      , TreeSitter.Unmarshal
                      , TreeSitter.Language
@@ -62,11 +80,9 @@ library
   c-sources:           src/bridge.c
                      , vendor/tree-sitter/lib/src/lib.c
   cc-options:          -std=c99
-  ghc-options:         -Wall -fno-warn-name-shadowing
-  if (impl(ghc >= 8.8))
-    ghc-options: -Wno-missing-deriving-strategies
 
 test-suite test
+  import: common
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
@@ -74,13 +90,12 @@ test-suite test
                      , tree-sitter
                      , hedgehog >= 0.6 && <2
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
 
 test-suite codegen-test
+  import: common
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test-codegen
   main-is:          test-codegen.hs
-  default-language: Haskell2010
   build-depends:    base
                   , tree-sitter
                   , hedgehog >= 0.6 && <2

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -63,6 +63,8 @@ library
                      , vendor/tree-sitter/lib/src/lib.c
   cc-options:          -std=c99
   ghc-options:         -Wall -fno-warn-name-shadowing
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -18,7 +18,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 8.6.5
-  -- GHC == 8.8.1
+  GHC == 8.8.1
 
 extra-source-files:  vendor/tree-sitter/lib/src/*.c
                    , vendor/tree-sitter/lib/src/*.h


### PR DESCRIPTION
This PR:

- [x] Enables a bunch of warnings everywhere.
- [x] Fixes a bunch of warnings.
- [x] Enables testing against ghc 8.8.1 in CI.

This doesn’t touch any version bounds (all of that happened in `semantic-source` & `semilattices`, both of which were minor versions), so this doesn’t require any new releases, altho it does resolve some harmless warnings which occur newly in ghc 8.8.1 by default.