### PR TITLE
Reversion tree-sitter-json & correct its lower bound on tree-sitter

### DIFF
--- a/script/build-and-upload
+++ b/script/build-and-upload
@@ -94,3 +94,6 @@ set -x
 
 cabal upload --publish "$TGZ_LOC"
 cabal upload --publish --documentation "$DOCS_LOC"
+
+echo "Tagging $PACKAGE_VERSION"
+git tag "$PACKAGE_VERSION"

--- a/script/build-and-upload
+++ b/script/build-and-upload
@@ -97,3 +97,4 @@ cabal upload --publish --documentation "$DOCS_LOC"
 
 echo "Tagging $PACKAGE_VERSION"
 git tag "$PACKAGE_VERSION"
+git push --tags

--- a/tree-sitter-go/tree-sitter-go.cabal
+++ b/tree-sitter-go/tree-sitter-go.cabal
@@ -4,7 +4,7 @@ version:             0.2.0.1
 synopsis:            Tree-sitter grammar/parser for Go
 description:         This package provides a parser for Go suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-go#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-go
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          tclem@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-haskell/tree-sitter-haskell.cabal
+++ b/tree-sitter-haskell/tree-sitter-haskell.cabal
@@ -67,4 +67,4 @@ library tree-sitter-haskell-internal
 
 source-repository head
   type:     git
-  location: https://github.com/tree-sitter/tree-sitter-haskell
+  location: https://github.com/tree-sitter/haskell-tree-sitter

--- a/tree-sitter-haskell/tree-sitter-haskell.cabal
+++ b/tree-sitter-haskell/tree-sitter-haskell.cabal
@@ -4,7 +4,7 @@ version:             0.2.0.1
 synopsis:            Tree-sitter grammar/parser for Haskell (with GHC extensions)
 description:         This package provides a parser for Haskell suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-haskell#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-haskell
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          tclem@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-java/ChangeLog.md
+++ b/tree-sitter-java/ChangeLog.md
@@ -2,6 +2,9 @@
 
 * AST datatypes use a shared `Token` datatype for all anonymous leaves.
 * Bumps the lower bound on `tree-sitter` to 0.5.
+* AST named sum datatypes are represented as `newtype` wrappers around sums constructed with `:+:`.
+* AST named & anonymous sum types are represented as balanced binary trees of `:+:`s instead of right-chained lists.
+* Rename the `bytes` field of leaves to `text`.
 
 # v0.3.0.0
 

--- a/tree-sitter-java/ChangeLog.md
+++ b/tree-sitter-java/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.4.0.0
+
+* AST datatypes use a shared `Token` datatype for all anonymous leaves.
+* Bumps the lower bound on `tree-sitter` to 0.5.
+
 # v0.3.0.0
 
 * Adds AST datatypes in `TreeSitter.Java.AST` which you can use with `TreeSitter.Unmarshal`.

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-java
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Tree-sitter grammar/parser for Java
 description:         This package provides a parser for Java suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -37,7 +37,7 @@ library
     TreeSitter.Java
     TreeSitter.Java.AST
   build-depends:       base              >= 4.12 && < 5
-                     , tree-sitter      ^>= 0.4
+                     , tree-sitter      ^>= 0.5
                      , template-haskell  >= 2.12 && < 2.16
                      , tree-sitter-java-internal
 

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -4,7 +4,7 @@ version:             0.4.0.0
 synopsis:            Tree-sitter grammar/parser for Java
 description:         This package provides a parser for Java suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-go#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-java
 author:              Ayman Nadeem, Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey
 maintainer:          tclem@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-json/ChangeLog.md
+++ b/tree-sitter-json/ChangeLog.md
@@ -1,4 +1,4 @@
-# 0.2.1.0
+# 0.3.0.0
 
 - Defines AST datatypes.
 - Bumps the lower bound on `tree-sitter` to 0.4.

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -4,7 +4,7 @@ version:             0.3.0.0
 synopsis:            Tree-sitter grammar/parser for JSON
 description:         This package provides a parser for JSON suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-json#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-json
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          vera@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -39,7 +39,7 @@ library
   build-depends:       base              >= 4.12 && < 5
                      , template-haskell  >= 2.12 && < 2.16
                      , text             ^>= 1.2.3.1
-                     , tree-sitter      ^>= 0.4
+                     , tree-sitter      ^>= 0.5
                      , tree-sitter-json-internal
 
 library tree-sitter-json-internal

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-json
-version:             0.2.1.0
+version:             0.3.0.0
 synopsis:            Tree-sitter grammar/parser for JSON
 description:         This package provides a parser for JSON suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-nix/tree-sitter-nix.cabal
+++ b/tree-sitter-nix/tree-sitter-nix.cabal
@@ -4,7 +4,7 @@ version:             0.2.0.1
 synopsis:            tree-sitter Nix language bindings
 description:         A parser for Nix for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/haskell-tree-sitter#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-nix
 author:              Robert Hensing
 maintainer:          Robert Hensing
 copyright:           Hercules Labs OÜ

--- a/tree-sitter-php/tree-sitter-php.cabal
+++ b/tree-sitter-php/tree-sitter-php.cabal
@@ -4,7 +4,7 @@ version:             0.2.0.1
 synopsis:            Tree-sitter grammar/parser for PHP
 description:         This package provides a parser for PHP suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-php#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-php
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          vera@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-python/ChangeLog.md
+++ b/tree-sitter-python/ChangeLog.md
@@ -2,6 +2,9 @@
 
 * AST datatypes use a shared `Token` datatype for all anonymous leaves.
 * Bumps the lower bound on `tree-sitter` to 0.5.
+* AST named sum datatypes are represented as `newtype` wrappers around sums constructed with `:+:`.
+* AST named & anonymous sum types are represented as balanced binary trees of `:+:`s instead of right-chained lists.
+* Rename the `bytes` field of leaves to `text`.
 
 # v0.5.0.0
 

--- a/tree-sitter-python/ChangeLog.md
+++ b/tree-sitter-python/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.6.0.0
+
+* AST datatypes use a shared `Token` datatype for all anonymous leaves.
+* Bumps the lower bound on `tree-sitter` to 0.5.
+
 # v0.5.0.0
 
 * Bumps `tree-sitter` to `^>= 0.4`.

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-python
-version:             0.5.0.0
+version:             0.6.0.0
 synopsis:            Tree-sitter grammar/parser for Python
 description:         This package provides a parser for Python suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -36,7 +36,7 @@ library
   exposed-modules:     TreeSitter.Python
                      , TreeSitter.Python.AST
   build-depends:       base              >= 4.12 && < 5
-                     , tree-sitter      ^>= 0.4
+                     , tree-sitter      ^>= 0.5
                      , aeson            ^>= 1.4.2.0
                      , directory        ^>= 1.3
                      , filepath         ^>= 1.4

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -4,7 +4,7 @@ version:             0.6.0.0
 synopsis:            Tree-sitter grammar/parser for Python
 description:         This package provides a parser for Python suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-python#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-python
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          tclem@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-ruby/tree-sitter-ruby.cabal
+++ b/tree-sitter-ruby/tree-sitter-ruby.cabal
@@ -4,7 +4,7 @@ version:             0.2.0.1
 synopsis:            Tree-sitter grammar/parser for Ruby
 description:         This package provides a parser for Ruby suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-ruby#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-ruby
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          tclem@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -52,4 +52,4 @@ library tree-sitter-tsx-internal
 
 source-repository head
   type:     git
-  location: https://github.com/tree-sitter/tree-sitter-typescript
+  location: https://github.com/tree-sitter/haskell-tree-sitter

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -4,7 +4,7 @@ version:             0.2.1.1
 synopsis:            Tree-sitter grammar/parser for TSX
 description:         This package provides a parser for TSX (TypeScript + XML) suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-typescript#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-tsx
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          vera@github.com
 copyright:           2017 GitHub

--- a/tree-sitter-typescript/tree-sitter-typescript.cabal
+++ b/tree-sitter-typescript/tree-sitter-typescript.cabal
@@ -4,7 +4,7 @@ version:             0.2.1.1
 synopsis:            Tree-sitter grammar/parser for TypeScript
 description:         This package provides a parser for TypeScript suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
-homepage:            https://github.com/tree-sitter/tree-sitter-typescript#readme
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-typescript
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
 maintainer:          vera@github.com
 copyright:           2017 GitHub

--- a/tree-sitter/ChangeLog.md
+++ b/tree-sitter/ChangeLog.md
@@ -1,3 +1,8 @@
+### v0.5.0.0
+
+* Use a shared `Token` type for anonymous leaves in generated AST types.
+* Allow generated ASTs to override the representation for portions of the AST by defining specialized datatypes. Note that this should be used sparingly to keep the maintenance burden of the AST types low.
+
 ### v0.4.0.0
 
 * `Unmarshal` has been split into `Unmarshal`, `UnmarshalAnn`, and `UnmarshalField`, with the first newly taking type constructors of kind `* -> *`. `UnmarshalAnn` can be used to unmarshal annotation types relating to the entire node, and `UnmarshalField` can be used to unmarshal fields of zero or more nodes.

--- a/tree-sitter/ChangeLog.md
+++ b/tree-sitter/ChangeLog.md
@@ -2,6 +2,9 @@
 
 * Use a shared `Token` type for anonymous leaves in generated AST types.
 * Allow generated ASTs to override the representation for portions of the AST by defining specialized datatypes. Note that this should be used sparingly to keep the maintenance burden of the AST types low.
+* Generate named sum types as `newtype` wrappers around sums constructed with `:+:`.
+* Generate named & anonymous sum types as balanced binary trees of `:+:`s instead of right-chained lists.
+* Rename the `bytes` field of leaves to `text`.
 
 ### v0.4.0.0
 

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -114,7 +114,7 @@ ctorForProductType constructorName typeParameterName children fields = ctorForTy
 ctorForLeafType :: DatatypeName -> Name -> Q Con
 ctorForLeafType (DatatypeName name) typeParameterName = ctorForTypes name
   [ ("ann",  varT typeParameterName) -- ann :: a
-  , ("text", conT ''Text)
+  , ("text", conT ''Text)            -- text :: Text
   ]
 
 -- | Build Q Constructor for records

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -113,8 +113,8 @@ ctorForProductType constructorName typeParameterName children fields = ctorForTy
 -- | Build Q Constructor for leaf types (nodes with no fields or subtypes)
 ctorForLeafType :: DatatypeName -> Name -> Q Con
 ctorForLeafType (DatatypeName name) typeParameterName = ctorForTypes name
-  [ ("ann",   varT typeParameterName) -- ann :: a
-  , ("bytes", conT ''Text)
+  [ ("ann",  varT typeParameterName) -- ann :: a
+  , ("text", conT ''Text)
   ]
 
 -- | Build Q Constructor for records

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter
-version:             0.4.0.0
+version:             0.5.0.0
 synopsis:            Unstable bindings for the tree-sitter parsing library.
 description:         Tree-sitter is a parser generator tool and an incremental parsing library.
                      .


### PR DESCRIPTION
We can’t release `tree-sitter-json` on `master` as 0.2.1.0, because it requires us to have the `skipDefined` codegen stuff, which isn’t available in a published `tree-sitter`.

- [x] Depends on #225.
- [x] Fixes #132.
- [x] Fixes #194.
- [x] Fixes #229.

**To-do:**

- [x] Release `tree-sitter-0.5.0.0`.
- [x] Release `tree-sitter-java-0.4.0.0`.
- [x] Release `tree-sitter-json-0.3.0.0`.
- [x] Release `tree-sitter-python-0.6.0.0`.