### PR TITLE
Python AST fixes for `import_from_statement`

### DIFF
--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -28,10 +28,14 @@ The remaining document provides more details on generating ASTs, inspecting data
 ___
 
 ### Table of Contents
-- [Generating ASTs](#Generating-ASTs)
-- [Inspecting auto-generated datatypes](#Inspecting-auto-generated-datatypes)
-- [Tests](#tests)
-- [Additional notes](#Additional-notes)
+- [CodeGen Documentation](#codegen-documentation)
+    - [Prerequisites](#prerequisites)
+    - [CodeGen Pipeline](#codegen-pipeline)
+    - [Table of Contents](#table-of-contents)
+    - [Generating ASTs](#generating-asts)
+    - [Inspecting auto-generated datatypes](#inspecting-auto-generated-datatypes)
+    - [Tests](#tests)
+    - [Additional notes](#additional-notes)
 ___
 
 ### Generating ASTs
@@ -44,21 +48,21 @@ To parse source code and produce ASTs locally:
 cabal new-repl lib:tree-sitter-python
 ```
 
-2. Set language extensions, `OverloadedStrings` and `TypeApplications`, and import relevant modules, `TreeSitter.Unmarshal`, `TreeSitter.Range` and `TreeSitter.Span`:
+2. Set language extensions, `OverloadedStrings` and `TypeApplications`, and import relevant modules, `TreeSitter.Unmarshal`, `Source.Range` and `Source.Span`:
 
 ```
 :seti -XOverloadedStrings
 :seti -XTypeApplications
 
-import TreeSitter.Span
-import TreeSitter.Range
+import Source.Span
+import Source.Range
 import TreeSitter.Unmarshal
 ```
 
 3. You can now call `parseByteString`, passing in the desired language you wish to parse (in this case Python exemplified by `tree_sitter_python`), and the source code (in this case an integer `1`). Since the function is constrained by `(Unmarshal t, UnmarshalAnn a)`, you can use type applications to provide a top-level node `t`, an entry point into the tree, in addition to a polymorphic annotation `a` used to represent range and span:
 
 ```
-parseByteString @(TreeSitter.Python.AST.Module (TreeSitter.Range.Range, Span)) tree_sitter_python "1"
+parseByteString @TreeSitter.Python.AST.Module @(Source.Span.Span, Source.Range.Range) tree_sitter_python "1"
 ```
 
 This generates the following AST:

--- a/tree-sitter/src/TreeSitter/Strings.hs
+++ b/tree-sitter/src/TreeSitter/Strings.hs
@@ -1,0 +1,24 @@
+module TreeSitter.Strings
+  ( camelCase
+  , capitalize
+  , pascalCase
+  ) where
+
+import Data.Char (toUpper)
+
+-- | Convert a snake_case String to camelCase
+camelCase :: String -> String
+camelCase = foldr appender mempty
+  where
+    appender :: Char -> String -> String
+    appender '_' cs = capitalize cs
+    appender c cs   = c : cs
+
+-- | Capitalize a String
+capitalize :: String -> String
+capitalize (c:cs) = toUpper c : cs
+capitalize []     = []
+
+-- | Convert a snake_case String to PascalCase
+pascalCase :: String -> String
+pascalCase = capitalize . camelCase

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -37,6 +37,7 @@ import           TreeSitter.Language as TS
 import           TreeSitter.Node as TS
 import           TreeSitter.Parser as TS
 import           TreeSitter.Tree as TS
+import           TreeSitter.Strings
 import           TreeSitter.Token as TS
 import           Source.Loc
 import           Source.Span
@@ -246,7 +247,7 @@ peekFieldName = do
   if fieldName == nullPtr then
     pure Nothing
   else
-    Just . FieldName <$> liftIO (peekCString fieldName)
+    Just . FieldName . camelCase <$> liftIO (peekCString fieldName)
 
 
 type Fields = Map.Map FieldName [Node]

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -180,7 +180,7 @@ instance UnmarshalField NonEmpty where
     head' <- unmarshalNode x
     tail' <- unmarshalField xs
     pure $ head' :| tail'
-  unmarshalField [] = fail "expected a node but didn't get one"
+  unmarshalField [] = fail "expected a node of type (NonEmpty a) but got an empty list"
 
 
 class SymbolMatching (a :: * -> *) where
@@ -367,6 +367,6 @@ instance (UnmarshalField f, Unmarshal g, Selector c) => GUnmarshalProduct (M1 S 
 instance (Unmarshal t, Selector c) => GUnmarshalProduct (M1 S c (Rec1 t)) where
   gunmarshalProductNode _ fields =
     case lookupField (FieldName (selName @c undefined)) fields of
-      []  -> fail "expected a node but didn't get one"
+      []  -> fail $ "expected a node '" <> selName @c undefined <> "' but didn't get one"
       [x] -> M1 . Rec1 <$> unmarshalNode x
       _   -> fail "expected a node but got multiple"

--- a/tree-sitter/test-codegen/test-codegen.hs
+++ b/tree-sitter/test-codegen/test-codegen.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE TemplateHaskell, TypeApplications #-}
 module Main (main) where
 
-import Hedgehog
+import           Control.Monad
+import           Data.Bool (bool)
+import           Data.Char
+import           Data.Foldable
+import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Data.Bool (bool)
-import Data.Char
-import TreeSitter.GenerateSyntax
-import Data.Foldable
-import Control.Monad
-import System.Exit (exitFailure, exitSuccess)
-import TreeSitter.Symbol
+import           System.Exit (exitFailure, exitSuccess)
+import           TreeSitter.Strings
+import           TreeSitter.Symbol
 
 -- | Generate permutations of alphabet and underscore combinations
 snakeChar :: MonadGen m => m Char
@@ -23,10 +23,10 @@ snakeChar = Gen.choice
 genSnake :: Gen String
 genSnake = Gen.string (Range.constant 1 10) snakeChar
 
-prop_removeUnderscore :: Property
-prop_removeUnderscore = property $ do
+prop_camelCase :: Property
+prop_camelCase = property $ do
   xs <- forAll $ Gen.string (Range.constant 1 5) snakeChar
-  assert ('_' `notElem` removeUnderscore xs)
+  assert ('_' `notElem` camelCase xs)
 
 initialCaps :: MonadGen m => m Char
 initialCaps = Gen.frequency
@@ -38,7 +38,7 @@ initialCaps = Gen.frequency
 prop_initUpper :: Property
 prop_initUpper = property $ do
   x:xs <- forAll (Gen.string (Range.constant 1 5) initialCaps)
-  y:_  <- pure $ initUpper (x:xs)
+  y:_  <- pure $ capitalize (x:xs)
   when (isLower x) (assert (isUpper y))
 
 prop_escapePunct :: Property
@@ -48,4 +48,4 @@ prop_escapePunct = property $ do
   where p = not . (\c -> isSpace c || c == '_' )
 
 main :: IO ()
-main = checkParallel $$(discover) >>= bool exitFailure exitSuccess
+main = checkParallel $$discover >>= bool exitFailure exitSuccess

--- a/tree-sitter/test/Test.hs
+++ b/tree-sitter/test/Test.hs
@@ -1,0 +1,19 @@
+module Main (main) where
+
+import           Control.Monad
+import           System.Exit (exitFailure)
+import           System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
+import qualified TreeSitter.Example
+import qualified TreeSitter.Strings.Example
+
+main :: IO ()
+main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
+
+  results <- sequence [
+      TreeSitter.Example.tests
+    , TreeSitter.Strings.Example.tests
+    ]
+
+  unless (and results) exitFailure

--- a/tree-sitter/test/Test.hs
+++ b/tree-sitter/test/Test.hs
@@ -1,8 +1,9 @@
 module Main (main) where
 
-import           Control.Monad
-import           System.Exit (exitFailure)
-import           System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
+import Control.Monad
+import System.Exit (exitFailure)
+import System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
+
 import qualified TreeSitter.Example
 import qualified TreeSitter.Strings.Example
 

--- a/tree-sitter/test/TreeSitter/Example.hs
+++ b/tree-sitter/test/TreeSitter/Example.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE TemplateHaskell #-}
-module Main (main) where
+module TreeSitter.Example (tests) where
 
-import Data.Bool (bool)
 import Control.Monad.IO.Class
 import Foreign
 import Foreign.C.Types
 import Hedgehog
-import System.Exit (exitFailure, exitSuccess)
 import TreeSitter.Cursor
 import TreeSitter.Node
 import TreeSitter.Parser
+
+tests :: IO Bool
+tests = checkSequential $$(discover)
 
 prop_TSNode_sizeOf = property $
   sizeOf (undefined :: TSNode) === fromIntegral sizeof_tsnode
@@ -43,9 +44,6 @@ prop_Parser_timeout = property $ do
   timeout <- liftIO (ts_parser_timeout_micros parser)
   timeout === 1000
   liftIO (ts_parser_delete parser)
-
-main :: IO ()
-main = checkSequential $$(discover) >>= bool exitFailure exitSuccess
 
 foreign import ccall unsafe "src/bridge.c sizeof_tsnode" sizeof_tsnode :: CSize
 foreign import ccall unsafe "src/bridge.c sizeof_tspoint" sizeof_tspoint :: CSize

--- a/tree-sitter/test/TreeSitter/Strings/Example.hs
+++ b/tree-sitter/test/TreeSitter/Strings/Example.hs
@@ -1,16 +1,17 @@
-{-# LANGUAGE TemplateHaskell, TypeApplications #-}
-module Main (main) where
+{-# LANGUAGE TemplateHaskell #-}
+module TreeSitter.Strings.Example (tests) where
 
 import           Control.Monad
-import           Data.Bool (bool)
 import           Data.Char
 import           Data.Foldable
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import           System.Exit (exitFailure, exitSuccess)
 import           TreeSitter.Strings
 import           TreeSitter.Symbol
+
+tests :: IO Bool
+tests = checkParallel $$(discover)
 
 -- | Generate permutations of alphabet and underscore combinations
 snakeChar :: MonadGen m => m Char
@@ -46,6 +47,3 @@ prop_escapePunct = property $ do
   xs <- forAll $ Gen.string (Range.constant 1 5) (Gen.filter p Gen.ascii)
   traverse_ (assert . isAlphaNum) (escapeOperatorPunctuation xs)
   where p = not . (\c -> isSpace c || c == '_' )
-
-main :: IO ()
-main = checkParallel $$discover >>= bool exitFailure exitSuccess

--- a/tree-sitter/test/TreeSitter/Strings/Example.hs
+++ b/tree-sitter/test/TreeSitter/Strings/Example.hs
@@ -36,8 +36,8 @@ initialCaps = Gen.frequency
   , (1, Gen.lower)
   ]
 
-prop_initUpper :: Property
-prop_initUpper = property $ do
+prop_capitalize :: Property
+prop_capitalize = property $ do
   x:xs <- forAll (Gen.string (Range.constant 1 5) initialCaps)
   y:_  <- pure $ capitalize (x:xs)
   when (isLower x) (assert (isUpper y))

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -86,20 +86,13 @@ test-suite test
   import: common
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
-  main-is:             Spec.hs
+  main-is:             Test.hs
+  other-modules:       TreeSitter.Example
+  other-modules:       TreeSitter.Strings.Example
   build-depends:       base
                      , tree-sitter
                      , hedgehog >= 0.6 && <2
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-
-test-suite codegen-test
-  import: common
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test-codegen
-  main-is:          test-codegen.hs
-  build-depends:    base
-                  , tree-sitter
-                  , hedgehog >= 0.6 && <2
 
 source-repository head
   type:     git

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -64,6 +64,7 @@ library
                      , TreeSitter.Unmarshal
                      , TreeSitter.Language
                      , TreeSitter.Node
+                     , TreeSitter.Strings
                      , TreeSitter.Symbol
                      , TreeSitter.Tree
                      , TreeSitter.GenerateSyntax


### PR DESCRIPTION
I noticed that python imports like `from foo import a, b, c` are not unmarshalling properly with an error `expected a node but didn't get one`. In debugging this, I've added a unit test, made the error messages a bit more informative and unique, and made a naming fix.

I'm now running into an issue in tree-sitter-python. `master` has the proper node-types.json for `import_from_statement`, but is missing a top level definition of `keyword_identifier`. If you use the following patch to manually fix `import_from_statement`, these tests pass.

``` diff
diff --git a/src/node-types.json b/src/node-types.json
index 2587a32..5825ca6 100644
--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1370,8 +1370,8 @@
       }
     },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
         {
           "type": "wildcard_import",
```