### PR TITLE
Revert "Upgrade to fused-effects-1.0."

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,2 @@
 packages: tree-sitter tree-sitter-*
 jobs: $ncpus
-
-source-repository-package
-  type: git
-  location: https://github.com/fused-effects/fused-effects
-  tag: eb039082280697e5ed998740462cc13fbdcc85f7

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -51,7 +51,7 @@ library
                      , containers           ^>= 0.6.0.1
                      , directory            ^>= 1.3
                      , filepath             ^>= 1.4.1
-                     , fused-effects        ^>= 1
+                     , fused-effects         >= 0.4 && <1
                      , split                ^>= 0.2.3
                      , template-haskell      >= 2.12 && < 2.16
                      , text                 ^>= 1.2.3.1


### PR DESCRIPTION
Reverts tree-sitter/haskell-tree-sitter#233

This is a temporary revert until semantic is ready to upgrade to fused-effect 1.0 so that we can do a tree-sitter bump.