### PR TITLE
Json marshal

### DIFF
--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -55,6 +55,14 @@ instance (GFields f, GFields g) => GFields (f :*: g) where
 instance forall nam upack strict lazy p . (GValue p, KnownSymbol nam) => GFields (S1 ('MetaSel ('Just nam) upack strict lazy) p) where
   gfields acc (M1 x) = (Text.pack (symbolVal (Proxy @nam)), gvalue x) : acc
 
+-- GValue for leaves
+instance ToJSON a => GValue (K1 i a) where
+  gvalue = toJSON . unK1
+
+-- Par1 instance
+instance GValue Par1 where
+  gvalue = toJSON . unPar1
+
 -- Define a new class to operate on product field types;
 -- Takes an accumulator, a datatype, and returns a new accumulator value.
 class GFields f where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+
 module TreeSitter.Marshal.JSON where
 
 import Data.Aeson as Aeson

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -27,7 +27,7 @@ data Bar a = Bar
   -- Aeson requires that the datatypes derive Generic
   -- we want Generic1 because we can represent types of kind * -> *
 
--- Serialize unmarshaled ASTs into JSON representation by auto-deriving instances generically.
+-- Serialize unmarshaled ASTs into JSON representation by auto-deriving Aeson instances generically
 class MarshalJSON t where
   marshal :: (ToJSON a) => t a -> Value
   default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t), ToJSON a) => t a -> Value

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -3,7 +3,12 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module TreeSitter.Marshal.JSON where
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -28,7 +28,7 @@ data Bar a = Bar
 
 -- Typeclass to generically marshal ASTs into JSON
 class MarshalJSON t where
-  marshal :: t a -> Value
+  marshal :: (ToJSON a) => t a -> Value
   default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t), ToJSON a) => t a -> Value
   marshal = gmarshal . from1
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -41,6 +41,10 @@ instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
 instance GFields bod => GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
   gmarshal = object . gfields [] . unM1
 
+-- Implement the product case
+instance (GFields f, GFields g) => GFields (f :*: g) where
+  gfields acc (f :*: g) = gfields (gfields acc g) f
+
 -- Define a new class to operate on product field types;
 -- Takes an accumulator, a datatype, and returns a new accumulator value.
 class GFields f where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -8,6 +8,10 @@ module TreeSitter.Marshal.JSON where
 import Data.Aeson as Aeson
 import GHC.Generics
 
+-- Serialize unmarshaled ASTs into JSON representation.
+
+-- AST nodes are expressed as products, sums, named or anonymous leaves, meaning we can generically iterate over them and pass the results to Aeson to be expressed as JSON objects.
+
 -- Typeclass to generically marshal ASTs into JSON
 class MarshalJSON t where
   marshal :: t a -> Value

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -50,3 +50,5 @@ instance GFields (S1 ('MetaSel ('Just fieldname) upack strict lazy) p) where
 -- Takes an accumulator, a datatype, and returns a new accumulator value.
 class GFields f where
   gfields :: ToJSON a => [(Text, Value)] -> f a -> [(Text, Value)]
+class GValue f where
+  gvalue :: (ToJSON a) => f a -> Value

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module TreeSitter.Marshal.JSON where
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -24,6 +24,8 @@ data Bar a = Bar
   { ann :: a
   , foo :: Text
   } deriving (Eq, Show, Generic1)
+  -- Aeson requires that the datatypes derive Generic
+  -- we want Generic1 because we can represent types of kind * -> *
 
 -- Serialize unmarshaled ASTs into JSON representation by auto-deriving instances generically.
 class MarshalJSON t where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -29,11 +29,11 @@ data Bar a = Bar
 -- Typeclass to generically marshal ASTs into JSON
 class MarshalJSON t where
   marshal :: t a -> Value
-  default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t)) => t a -> Value
+  default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t), ToJSON a) => t a -> Value
   marshal = gmarshal . from1
 
 class GMarshalJSON f where
-  gmarshal :: f a -> Value
+  gmarshal :: (ToJSON a) => f a -> Value
 
 instance GMarshalJSON Bar
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -33,7 +33,8 @@ class MarshalJSON t where
   default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t), ToJSON a) => t a -> Value
   marshal = gmarshal . from1
 
--- Typeclass to generically marshal ASTs into JSON.
+-- Typeclass to generically marshal ASTs into JSON
+-- Given some type @a@ that's an instance of @ToJSON@, we apply a function @f@ and return a JSON value represented as a Haskell value
 class GMarshalJSON f where
   gmarshal :: (ToJSON a) => f a -> Value
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -22,7 +22,7 @@ import GHC.TypeLits
 -- Test datatype that will go away: this is just to get us started!
 data Bar a = Bar
   { ann :: a
-   , guy :: Text
+  , foo :: Text
   } deriving (Eq, Show, Generic1)
 
 -- Serialize unmarshaled ASTs into JSON representation by auto-deriving instances generically.

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -4,6 +4,7 @@
 module TreeSitter.Marshal.JSON where
 
 import Data.Aeson as Aeson
+import GHC.Generics
 
 -- Typeclass to generically marshal ASTs into JSON
 class MarshalJSON t where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -11,3 +11,5 @@ class MarshalJSON t where
   marshal :: t a -> Value
   default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t)) => t a -> Value
   marshal = gmarshal . from1
+class GMarshalJSON f where
+  gmarshal :: f a -> Value

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -38,7 +38,7 @@ instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
   gmarshal = gmarshal . unM1
 
 -- Need to fold over S1 product types and pass the result to Aeson objects
-instance GFields bod => GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
+instance GFields bod => GMarshalJSON (C1 (Meta ctorname x y) bod) where
   gmarshal = object . gfields [] . unM1
 
 -- Implement the product case

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -8,6 +8,8 @@ module TreeSitter.Marshal.JSON where
 import Data.Aeson as Aeson
 import GHC.Generics
 import Data.Proxy
+import Data.Text (Text)
+import qualified Data.Text as Text
 
 -- Serialize unmarshaled ASTs into JSON representation.
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -17,10 +17,7 @@ data Bar a = Bar
    , guy :: Text
   } deriving (Eq, Show, Generic1)
 
-
--- Serialize unmarshaled ASTs into JSON representation.
-
--- AST nodes are expressed as products, sums, named or anonymous leaves, meaning we can generically iterate over them and pass the results to Aeson to be expressed as JSON objects.
+-- Serialize unmarshaled ASTs into JSON representation by auto-deriving instances generically.
 
 -- Typeclass to generically marshal ASTs into JSON
 class MarshalJSON t where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeApplications #-}
 
 module TreeSitter.Marshal.JSON where
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -7,6 +7,7 @@ module TreeSitter.Marshal.JSON where
 
 import Data.Aeson as Aeson
 import GHC.Generics
+import Data.Proxy
 
 -- Serialize unmarshaled ASTs into JSON representation.
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -12,6 +12,12 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.TypeLits
 
+data Bar a = Bar
+  { ann :: a
+   , guy :: Text
+  } deriving (Eq, Show, Generic1)
+
+
 -- Serialize unmarshaled ASTs into JSON representation.
 
 -- AST nodes are expressed as products, sums, named or anonymous leaves, meaning we can generically iterate over them and pass the results to Aeson to be expressed as JSON objects.

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -1,0 +1,7 @@
+module TreeSitter.Marshal.JSON where
+
+import Data.Aeson as Aeson
+
+-- Typeclass to generically marshal ASTs into JSON
+class MarshalJSON t where
+  marshal :: t a -> Value

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -35,7 +35,7 @@ class MarshalJSON t where
 class GMarshalJSON f where
   gmarshal :: (ToJSON a) => f a -> Value
 
-instance GMarshalJSON Bar
+instance MarshalJSON Bar
 
 -- Stores meta-data for datatypes
 instance GMarshalJSON f => GMarshalJSON (M1 i c f) where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -79,3 +79,5 @@ class GFields f where
 -- since it's a function on types, we need a typeclass.
 class GValue f where
   gvalue :: (ToJSON a) => f a -> Value
+
+-- TODO: use toEncoding -- direct serialization to ByteString

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -38,7 +38,7 @@ class GMarshalJSON f where
 instance MarshalJSON Bar
 
 -- Stores meta-data for datatypes
-instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
+instance GMarshalJSON f => GMarshalJSON (M1 D c f) where
   gmarshal = gmarshal . unM1
 
 -- Need to fold over S1 product types and pass the result to Aeson objects

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -19,25 +19,29 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.TypeLits
 
+-- Test datatype that will go away: this is just to get us started!
 data Bar a = Bar
   { ann :: a
    , guy :: Text
   } deriving (Eq, Show, Generic1)
 
 -- Serialize unmarshaled ASTs into JSON representation by auto-deriving instances generically.
-
--- Typeclass to generically marshal ASTs into JSON
 class MarshalJSON t where
   marshal :: (ToJSON a) => t a -> Value
   default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t), ToJSON a) => t a -> Value
   marshal = gmarshal . from1
 
+-- Typeclass to generically marshal ASTs into JSON.
 class GMarshalJSON f where
   gmarshal :: (ToJSON a) => f a -> Value
 
+-- We need a marshal instance for the node datatype we wish to serialize.
 instance MarshalJSON Bar
 
+-- Generic instances
+
 -- Stores meta-data for datatypes
+-- using unM1 instead of pattern-matching on M1 to express with function composition
 instance GMarshalJSON f => GMarshalJSON (M1 D c f) where
   gmarshal = gmarshal . unM1
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -31,6 +31,8 @@ class MarshalJSON t where
 class GMarshalJSON f where
   gmarshal :: f a -> Value
 
+instance GMarshalJSON Bar
+
 -- Stores meta-data for datatypes
 instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
   gmarshal = gmarshal . unM1

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -42,7 +42,7 @@ instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
   gmarshal = gmarshal . unM1
 
 -- Need to fold over S1 product types and pass the result to Aeson objects
-instance GFields bod => GMarshalJSON (C1 (Meta ctorname x y) bod) where
+instance GFields bod => GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
   gmarshal = object . gfields [] . unM1
 
 -- Implement the product case

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
 
 module TreeSitter.Marshal.JSON where
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -59,8 +59,10 @@ instance (GFields f, GFields g) => GFields (f :*: g) where
 -- Implement base case
 -- Takes term-level value of the type-level string 'fieldname' by passing a Proxy specialised to 'fieldname' to the knownSymbol function.
 -- To actually get a value out of this datum, we'll need one more typeclass. Let's call its method 'gvalue'.
-instance forall nam upack strict lazy p . (GValue p, KnownSymbol nam) => GFields (S1 ('MetaSel ('Just nam) upack strict lazy) p) where
-  gfields acc (M1 x) = (Text.pack (symbolVal (Proxy @nam)), gvalue x) : acc
+instance (GValue p, Selector s) => GFields (S1 s p) where
+  gfields acc x = (Text.pack (selName x), gvalue (unM1 x)) : acc
+-- knows what the type of x is, whereas M1 has parameters that can be instantiated to anything
+
 
 -- GValue for leaves
 instance ToJSON a => GValue (K1 i a) where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -36,6 +36,11 @@ instance GMarshalJSON Bar
 -- Stores meta-data for datatypes
 instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
   gmarshal = gmarshal . unM1
+
+-- Need to fold over S1 product types and pass the result to Aeson objects
+instance GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
+  gmarshal = object . gfields [] . unM1
+
 -- Define a new class to operate on product field types;
 -- Takes an accumulator, a datatype, and returns a new accumulator value.
 class GFields f where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RankNTypes #-}
 
 module TreeSitter.Marshal.JSON where
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -46,7 +46,7 @@ instance GMarshalJSON f => GMarshalJSON (M1 D c f) where
   gmarshal = gmarshal . unM1
 
 -- Need to fold over S1 product types and pass the result to Aeson objects
-instance GFields fields => GMarshalJSON (C1 (MetaCons ctorname x y) fields) where
+instance GFields fields => GMarshalJSON (C1 ('MetaCons ctorname x y) fields) where
   gmarshal = object . gfields [] . unM1
 
 -- Implement the product case

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -10,6 +10,7 @@ import GHC.Generics
 import Data.Proxy
 import Data.Text (Text)
 import qualified Data.Text as Text
+import GHC.TypeLits
 
 -- Serialize unmarshaled ASTs into JSON representation.
 

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -38,7 +38,7 @@ instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
   gmarshal = gmarshal . unM1
 
 -- Need to fold over S1 product types and pass the result to Aeson objects
-instance GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
+instance GFields bod => GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
   gmarshal = object . gfields [] . unM1
 
 -- Define a new class to operate on product field types;

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -45,6 +45,10 @@ instance GFields bod => GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
 instance (GFields f, GFields g) => GFields (f :*: g) where
   gfields acc (f :*: g) = gfields (gfields acc g) f
 
+-- Implement base case
+instance GFields (S1 ('MetaSel ('Just fieldname) upack strict lazy) p) where
+  gfields acc (M1 x) = (_name, _value) : acc
+
 -- Define a new class to operate on product field types;
 -- Takes an accumulator, a datatype, and returns a new accumulator value.
 class GFields f where

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -46,7 +46,7 @@ instance GMarshalJSON f => GMarshalJSON (M1 D c f) where
   gmarshal = gmarshal . unM1
 
 -- Need to fold over S1 product types and pass the result to Aeson objects
-instance GFields bod => GMarshalJSON (C1 (MetaCons ctorname x y) bod) where
+instance GFields fields => GMarshalJSON (C1 (MetaCons ctorname x y) fields) where
   gmarshal = object . gfields [] . unM1
 
 -- Implement the product case

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -43,8 +43,10 @@ instance (GFields f, GFields g) => GFields (f :*: g) where
   gfields acc (f :*: g) = gfields (gfields acc g) f
 
 -- Implement base case
-instance GFields (S1 ('MetaSel ('Just fieldname) upack strict lazy) p) where
-  gfields acc (M1 x) = (_name, _value) : acc
+-- Takes term-level value of the type-level string 'fieldname' by passing a Proxy specialised to 'fieldname' to the knownSymbol function.
+-- To actually get a value out of this datum, we'll need one more typeclass. Let's call its method 'gvalue'.
+instance forall nam upack strict lazy p . (GValue p, KnownSymbol nam) => GFields (S1 ('MetaSel ('Just nam) upack strict lazy) p) where
+  gfields acc (M1 x) = (Text.pack (symbolVal (Proxy @nam)), gvalue x) : acc
 
 -- Define a new class to operate on product field types;
 -- Takes an accumulator, a datatype, and returns a new accumulator value.

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -9,3 +9,5 @@ import GHC.Generics
 -- Typeclass to generically marshal ASTs into JSON
 class MarshalJSON t where
   marshal :: t a -> Value
+  default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t)) => t a -> Value
+  marshal = gmarshal . from1

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -36,3 +36,7 @@ instance GMarshalJSON Bar
 -- Stores meta-data for datatypes
 instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
   gmarshal = gmarshal . unM1
+-- Define a new class to operate on product field types;
+-- Takes an accumulator, a datatype, and returns a new accumulator value.
+class GFields f where
+  gfields :: ToJSON a => [(Text, Value)] -> f a -> [(Text, Value)]

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -16,3 +16,7 @@ class MarshalJSON t where
 
 class GMarshalJSON f where
   gmarshal :: f a -> Value
+
+-- Stores meta-data for datatypes
+instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
+  gmarshal (M1 x) = gmarshal x

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -13,5 +13,6 @@ class MarshalJSON t where
   marshal :: t a -> Value
   default marshal :: ( Generic1 t, GMarshalJSON (Rep1 t)) => t a -> Value
   marshal = gmarshal . from1
+
 class GMarshalJSON f where
   gmarshal :: f a -> Value

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -50,5 +50,8 @@ instance GFields (S1 ('MetaSel ('Just fieldname) upack strict lazy) p) where
 -- Takes an accumulator, a datatype, and returns a new accumulator value.
 class GFields f where
   gfields :: ToJSON a => [(Text, Value)] -> f a -> [(Text, Value)]
+
+-- gvalue is a wrapper that calls to @toJSON@ (for leaf node types such as Text) or recurses via @marshal@
+-- since it's a function on types, we need a typeclass.
 class GValue f where
   gvalue :: (ToJSON a) => f a -> Value

--- a/tree-sitter/src/TreeSitter/Marshal/JSON.hs
+++ b/tree-sitter/src/TreeSitter/Marshal/JSON.hs
@@ -23,4 +23,4 @@ class GMarshalJSON f where
 
 -- Stores meta-data for datatypes
 instance GMarshalJSON f => GMarshalJSON (M1 i c f) where
-  gmarshal (M1 x) = gmarshal x
+  gmarshal = gmarshal . unM1

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -68,6 +68,7 @@ library
                      , TreeSitter.Deserialize
                      , TreeSitter.Cursor
                      , TreeSitter.Token
+                     , TreeSitter.Marshal.JSON
   other-modules:       TreeSitter.Unmarshal.Examples
   include-dirs:        vendor/tree-sitter/lib/include
                      , vendor/tree-sitter/lib/src


### PR DESCRIPTION
Starting to do the work to generically serialize the generically unmarshaled ASTs into JSON format. This will (I think) entail marshaling those ASTs and auto-deriving `Aeson` and a few other typeclass instances in `GenerateSyntax` in order to be able to call `marshal` in `semantic-ast`. 