### PR TITLE
Revert "Revert "Upgrade to fused-effects-1.0.""

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -5,4 +5,3 @@
 import TreeSitter.Unmarshal
 import Source.Span
 import Source.Range
-:set prompt "> "

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,1 @@
 packages: tree-sitter tree-sitter-*
-jobs: $ncpus
-
-source-repository-package
-  type: git
-  location: https://github.com/fused-effects/fused-effects
-  tag: eb039082280697e5ed998740462cc13fbdcc85f7

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,7 @@
 packages: tree-sitter tree-sitter-*
 jobs: $ncpus
+
+source-repository-package
+  type: git
+  location: https://github.com/fused-effects/fused-effects
+  tag: eb039082280697e5ed998740462cc13fbdcc85f7

--- a/tree-sitter/src/TreeSitter/Unmarshal.hs
+++ b/tree-sitter/src/TreeSitter/Unmarshal.hs
@@ -16,9 +16,9 @@ module TreeSitter.Unmarshal
 ) where
 
 import           Control.Applicative
-import           Control.Effect hiding ((:+:))
-import           Control.Effect.Reader
-import           Control.Effect.Fail
+import           Control.Carrier.Reader
+import           Control.Carrier.Fail.Either
+import           Control.Carrier.Lift
 import           Control.Monad.IO.Class
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
@@ -60,9 +60,8 @@ parseByteString language bytestring = withParser language $ \ parser -> withPars
 --   Datatypes which can be constructed from tree-sitter parse trees may use the default definition of 'unmarshalNode' providing that they have a suitable 'Generic1' instance.
 class Unmarshal t where
   unmarshalNode
-    :: ( Carrier sig m
-       , Member (Reader ByteString) sig
-       , Member (Reader (Ptr Cursor)) sig
+    :: ( Has (Reader ByteString) sig m
+       , Has (Reader (Ptr Cursor)) sig m
        , MonadFail m
        , MonadIO m
        , UnmarshalAnn a
@@ -70,11 +69,10 @@ class Unmarshal t where
     => Node
     -> m (t a)
   default unmarshalNode
-    :: ( Carrier sig m
-       , Generic1 t
+    :: ( Generic1 t
        , GUnmarshal (Rep1 t)
-       , Member (Reader ByteString) sig
-       , Member (Reader (Ptr Cursor)) sig
+       , Has (Reader ByteString) sig m
+       , Has (Reader (Ptr Cursor)) sig m
        , MonadFail m
        , MonadIO m
        , UnmarshalAnn a
@@ -108,9 +106,8 @@ instance Unmarshal (Token sym n) where
 --   Leaf nodes have 'Text.Text' fields, and leaves, anonymous leaves, and products all have parametric annotation fields. All of these fields are unmarshalled using the metadata of the node, e.g. its start/end bytes, without reference to any child nodes it may contain.
 class UnmarshalAnn a where
   unmarshalAnn
-    :: ( Carrier sig m
-       , Member (Reader ByteString) sig
-       , Member (Reader (Ptr Cursor)) sig
+    :: ( Has (Reader ByteString) sig m
+       , Has (Reader (Ptr Cursor)) sig m
        , MonadFail m
        , MonadIO m
        )
@@ -156,9 +153,8 @@ pointToPos (TSPoint line column) = Pos (fromIntegral line) (fromIntegral column)
 -- | Optional/repeated fields occurring in product datatypes are wrapped in type constructors, e.g. 'Maybe', '[]', or 'NonEmpty', and thus can unmarshal zero or more nodes for the same field name.
 class UnmarshalField t where
   unmarshalField
-    :: ( Carrier sig m
-       , Member (Reader ByteString) sig
-       , Member (Reader (Ptr Cursor)) sig
+    :: ( Has (Reader ByteString) sig m
+       , Has (Reader (Ptr Cursor)) sig m
        , MonadFail m
        , MonadIO m
        , Unmarshal f
@@ -213,11 +209,11 @@ sep :: String -> String -> String
 sep a b = a ++ ". " ++ b
 
 -- | Advance the cursor to the next sibling of the current node.
-step :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m Bool
+step :: (Has (Reader (Ptr Cursor)) sig m, MonadIO m) => m Bool
 step = ask >>= liftIO . ts_tree_cursor_goto_next_sibling
 
 -- | Run an action over the children of the current node.
-push :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m a -> m (Maybe a)
+push :: (Has (Reader (Ptr Cursor)) sig m, MonadIO m) => m a -> m (Maybe a)
 push m = do
   hasChildren <- ask >>= liftIO . ts_tree_cursor_goto_first_child
   if hasChildren then do
@@ -227,13 +223,13 @@ push m = do
     pure Nothing
 
 -- | Move the cursor to point at the passed 'TSNode'.
-goto :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => TSNode -> m ()
+goto :: (Has (Reader (Ptr Cursor)) sig m, MonadIO m) => TSNode -> m ()
 goto node = do
   cursor <- ask
   liftIO (with node (ts_tree_cursor_reset_p cursor))
 
 -- | Return the 'Node' that the cursor is pointing at.
-peekNode :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m Node
+peekNode :: (Has (Reader (Ptr Cursor)) sig m, MonadIO m) => m Node
 peekNode = do
   cursor <- ask
   liftIO $ alloca $ \ tsNodePtr -> do
@@ -243,7 +239,7 @@ peekNode = do
       peek nodePtr
 
 -- | Return the field name (if any) for the node that the cursor is pointing at (if any), or 'Nothing' otherwise.
-peekFieldName :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m (Maybe FieldName)
+peekFieldName :: (Has (Reader (Ptr Cursor)) sig m, MonadIO m) => m (Maybe FieldName)
 peekFieldName = do
   cursor <- ask
   fieldName <- liftIO $ ts_tree_cursor_current_field_name cursor
@@ -256,7 +252,7 @@ peekFieldName = do
 type Fields = Map.Map FieldName [Node]
 
 -- | Return the fields remaining in the current branch, represented as 'Map.Map' of 'FieldName's to their corresponding 'Node's.
-getFields :: (Carrier sig m, Member (Reader (Ptr Cursor)) sig, MonadIO m) => m Fields
+getFields :: (Has (Reader (Ptr Cursor)) sig m, MonadIO m) => m Fields
 getFields = go Map.empty
   where go fs = do
           node <- peekNode
@@ -293,9 +289,8 @@ newtype FieldName = FieldName { getFieldName :: String }
 --   Sum types are constructed by attempting to unmarshal each constructor nondeterministically. This should instead use the current node’s symbol to select the corresponding constructor deterministically.
 class GUnmarshal f where
   gunmarshalNode
-    :: ( Carrier sig m
-       , Member (Reader ByteString) sig
-       , Member (Reader (Ptr Cursor)) sig
+    :: ( Has (Reader ByteString) sig m
+       , Has (Reader (Ptr Cursor)) sig m
        , MonadFail m
        , MonadIO m
        , UnmarshalAnn a
@@ -342,9 +337,8 @@ instance (GUnmarshal f, GUnmarshal g, SymbolMatching f, SymbolMatching g) => GUn
 -- | Generically unmarshal products
 class GUnmarshalProduct f where
   gunmarshalProductNode
-    :: ( Carrier sig m
-       , Member (Reader ByteString) sig
-       , Member (Reader (Ptr Cursor)) sig
+    :: ( Has (Reader ByteString) sig m
+       , Has (Reader (Ptr Cursor)) sig m
        , MonadFail m
        , MonadIO m
        , UnmarshalAnn a

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -51,7 +51,7 @@ library
                      , containers           ^>= 0.6.0.1
                      , directory            ^>= 1.3
                      , filepath             ^>= 1.4.1
-                     , fused-effects         >= 0.4 && <1
+                     , fused-effects        ^>= 1
                      , split                ^>= 0.2.3
                      , template-haskell      >= 2.12 && < 2.16
                      , text                 ^>= 1.2.3.1

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter
-version:             0.7.0.0
+version:             0.7.1.0
 synopsis:            Unstable bindings for the tree-sitter parsing library.
 description:         Tree-sitter is a parser generator tool and an incremental parsing library.
                      .


### PR DESCRIPTION
We need this for semantic’s FE-1.0 work, though don’t merge this just yet.

Reverts tree-sitter/haskell-tree-sitter#244.