### PR TITLE
Ensure tree-sitter-python tests can be run with `cabal run` from the top-level project folder.

### DIFF
--- a/tree-sitter-java/test/Test.hs
+++ b/tree-sitter-java/test/Test.hs
@@ -10,7 +10,7 @@ import           TreeSitter.Unmarshal
 
 main :: IO ()
 main
-  =   readCorpusFiles (Path.relDir "./vendor/tree-sitter-java/corpus")
+  =   readCorpusFiles (Path.relDir "vendor/tree-sitter-java")
   >>= traverse (testCorpus parse)
   >>= defaultMain . tests
   where

--- a/tree-sitter-java/test/Test.hs
+++ b/tree-sitter-java/test/Test.hs
@@ -10,7 +10,7 @@ import           TreeSitter.Unmarshal
 
 main :: IO ()
 main
-  =   readCorpusFiles (Path.relDir "vendor/tree-sitter-java")
+  =   readCorpusFiles (Path.relDir "tree-sitter-java/vendor/tree-sitter-java/corpus")
   >>= traverse (testCorpus parse)
   >>= defaultMain . tests
   where

--- a/tree-sitter-python/test/Test.hs
+++ b/tree-sitter-python/test/Test.hs
@@ -10,7 +10,7 @@ import           TreeSitter.Unmarshal
 
 main :: IO ()
 main
-  =   readCorpusFiles (Path.relDir "vendor/tree-sitter-python/test")
+  =   readCorpusFiles (Path.relDir "tree-sitter-python/vendor/tree-sitter-python/test/corpus")
   >>= traverse (testCorpus parse)
   >>= defaultMain . tests
   where parse = parseByteString @Py.Module @() tree_sitter_python

--- a/tree-sitter-python/test/Test.hs
+++ b/tree-sitter-python/test/Test.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE DisambiguateRecordFields, OverloadedStrings, TypeApplications #-}
 module Main (main) where
 
-import           Control.Monad
-import           System.Path ((</>))
 import qualified System.Path as Path
-import           System.Path.Directory
 import           Test.Tasty
 import           TreeSitter.Python
 import qualified TreeSitter.Python.AST as Py
@@ -12,14 +9,11 @@ import           TreeSitter.Test.Helpers
 import           TreeSitter.Unmarshal
 
 main :: IO ()
-main = do
-  dir <- getCurrentDirectory
-  when (Path.takeDirName dir == Just (Path.relDir "haskell-tree-sitter")) $
-    setCurrentDirectory (dir </> Path.relDir "tree-sitter-python")
-  let parse = parseByteString @Py.Module @() tree_sitter_python
-  readCorpusFiles (Path.relDir "vendor/tree-sitter-python/corpus")
-    >>= traverse (testCorpus parse)
-    >>= defaultMain . tests
+main
+  =   readCorpusFiles (Path.relDir "vendor/tree-sitter-python")
+  >>= traverse (testCorpus parse)
+  >>= defaultMain . tests
+  where parse = parseByteString @Py.Module @() tree_sitter_python
 
 tests :: [TestTree] -> TestTree
 tests = testGroup "tree-sitter-python corpus tests"

--- a/tree-sitter-python/test/Test.hs
+++ b/tree-sitter-python/test/Test.hs
@@ -17,10 +17,9 @@ main = do
   when (Path.takeDirName dir == Just (Path.relDir "haskell-tree-sitter")) $
     setCurrentDirectory (dir </> Path.relDir "tree-sitter-python")
   let parse = parseByteString @Py.Module @() tree_sitter_python
-  readCorpusFiles (Path.relDir "./vendor/tree-sitter-python/corpus")
+  readCorpusFiles (Path.relDir "vendor/tree-sitter-python/corpus")
     >>= traverse (testCorpus parse)
     >>= defaultMain . tests
-  where
 
 tests :: [TestTree] -> TestTree
 tests = testGroup "tree-sitter-python corpus tests"

--- a/tree-sitter-python/test/Test.hs
+++ b/tree-sitter-python/test/Test.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DisambiguateRecordFields, OverloadedStrings, TypeApplications #-}
 module Main (main) where
 
+import           Control.Monad
+import           System.Path ((</>))
 import qualified System.Path as Path
+import           System.Path.Directory
 import           Test.Tasty
 import           TreeSitter.Python
 import qualified TreeSitter.Python.AST as Py
@@ -9,11 +12,15 @@ import           TreeSitter.Test.Helpers
 import           TreeSitter.Unmarshal
 
 main :: IO ()
-main
-  =   readCorpusFiles (Path.relDir "./vendor/tree-sitter-python/corpus")
-  >>= traverse (testCorpus parse)
-  >>= defaultMain . tests
-  where parse = parseByteString @Py.Module @() tree_sitter_python
+main = do
+  dir <- getCurrentDirectory
+  when (Path.takeDirName dir == Just (Path.relDir "haskell-tree-sitter")) $
+    setCurrentDirectory (dir </> Path.relDir "tree-sitter-python")
+  let parse = parseByteString @Py.Module @() tree_sitter_python
+  readCorpusFiles (Path.relDir "./vendor/tree-sitter-python/corpus")
+    >>= traverse (testCorpus parse)
+    >>= defaultMain . tests
+  where
 
 tests :: [TestTree] -> TestTree
 tests = testGroup "tree-sitter-python corpus tests"

--- a/tree-sitter-test-helpers/src/TreeSitter/Test/Helpers.hs
+++ b/tree-sitter-test-helpers/src/TreeSitter/Test/Helpers.hs
@@ -15,6 +15,7 @@ import           Data.Either
 import           Data.Functor
 import           Prelude hiding (takeWhile)
 import           System.Exit (exitFailure)
+import           System.Path ((</>))
 import qualified System.Path as Path
 import qualified System.Path.Directory as Path
 import           Test.Tasty
@@ -31,8 +32,22 @@ testCorpus parse path = do
     pass = const (pure ())
     errMsg code e = assertFailure (e <> "\n``` \n" <> unpack code <> "```")
 
+-- Depending on whether these tests are invoked via cabal run or cabal test,
+-- we might be in a project subdirectory or not, so let's make sure we're
+-- in project subdirectories as needed.
+findCorpus :: Path.RelDir -> IO Path.RelDir
+findCorpus p = Path.doesDirectoryExist p >>= go where
+  go exists
+    | exists    = pure (p </> Path.relDir "corpus")
+    | otherwise = do
+        project <- maybe (fail "Can't deduce corpus location") pure (Path.takeDirName p)
+        pure (project </> p </> Path.relDir "corpus")
+
+-- The path is expected to be relative to the language project.
 readCorpusFiles :: Path.RelDir ->  IO [Path.RelFile]
-readCorpusFiles dir = fmap (Path.combine dir) <$> Path.filesInDir dir
+readCorpusFiles parent = do
+  dir <- findCorpus parent
+  fmap (Path.combine dir) <$> Path.filesInDir dir
 
 data CorpusExample = CorpusExample { name :: String, code :: ByteString }
   deriving (Eq, Show)

--- a/tree-sitter-test-helpers/src/TreeSitter/Test/Helpers.hs
+++ b/tree-sitter-test-helpers/src/TreeSitter/Test/Helpers.hs
@@ -36,12 +36,11 @@ testCorpus parse path = do
 -- we might be in a project subdirectory or not, so let's make sure we're
 -- in project subdirectories as needed.
 findCorpus :: Path.RelDir -> IO Path.RelDir
-findCorpus p = Path.doesDirectoryExist p >>= go where
-  go exists
-    | exists    = pure (p </> Path.relDir "corpus")
-    | otherwise = do
-        project <- maybe (fail "Can't deduce corpus location") pure (Path.takeDirName p)
-        pure (project </> p </> Path.relDir "corpus")
+findCorpus p = do
+  cwd <- Path.getCurrentDirectory
+  if Path.takeDirName cwd == Just (Path.relDir "haskell-tree-sitter")
+     then pure p
+     else pure (Path.relDir ".." </> p)
 
 -- The path is expected to be relative to the language project.
 readCorpusFiles :: Path.RelDir ->  IO [Path.RelFile]


### PR DESCRIPTION
`cabal test` moves into the subproject's folder before running,
whereas `cabal run` doesn't. We can fix this by conditionally entering
the `tree-sitter-python` directory.