### PR TITLE
Static symbol lists

### DIFF
--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -37,11 +37,11 @@ astDeclarationsForLanguage language filePath = do
   let invocationRelativePath = takeDirectory (pwd </> currentFilename) </> filePath
   input <- runIO (eitherDecodeFileStrict' invocationRelativePath) >>= either fail pure
   allSymbols <- runIO (getAllSymbols language)
-  allSymbolNames <- [d|
-    allSymbolNames :: [String]
-    allSymbolNames = $(listE (map (litE . stringL . debugPrefix) allSymbols))
+  debugSymbolNames <- [d|
+    debugSymbolNames :: [String]
+    debugSymbolNames = $(listE (map (litE . stringL . debugPrefix) allSymbols))
     |]
-  (allSymbolNames <>) . concat @[] <$> traverse (syntaxDatatype language allSymbols) input
+  (debugSymbolNames <>) . concat @[] <$> traverse (syntaxDatatype language allSymbols) input
 
 -- Build a list of all symbols
 getAllSymbols :: Ptr TS.Language -> IO [(String, Named)]
@@ -96,7 +96,7 @@ symbolMatchingInstance allSymbols name named str = do
   let tsSymbols = elemIndices (str, named) allSymbols
       names = intercalate ", " $ fmap (debugPrefix . (!!) allSymbols) tsSymbols
   [d|instance TS.SymbolMatching $(conT name) where
-      showFailure _ node = "expected " <> $(litE (stringL (show names))) <> " but got " <> show (allSymbolNames !! fromIntegral (nodeSymbol node))
+      showFailure _ node = "expected " <> $(litE (stringL (show names))) <> " but got " <> show (debugSymbolNames !! fromIntegral (nodeSymbol node))
       symbolMatch _ node = elem (nodeSymbol node) tsSymbols|]
 
 -- | Prefix symbol names for debugging to disambiguate between Named and Anonymous nodes.

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -37,7 +37,11 @@ astDeclarationsForLanguage language filePath = do
   let invocationRelativePath = takeDirectory (pwd </> currentFilename) </> filePath
   input <- runIO (eitherDecodeFileStrict' invocationRelativePath) >>= either fail pure
   allSymbols <- runIO (getAllSymbols language)
-  concat @[] <$> traverse (syntaxDatatype language allSymbols) input
+  allSymbolNames <- [d|
+    allSymbolNames :: [String]
+    allSymbolNames = $(listE (map (litE . stringL . debugPrefix) allSymbols))
+    |]
+  (allSymbolNames <>) . concat @[] <$> traverse (syntaxDatatype language allSymbols) input
 
 -- Build a list of all symbols
 getAllSymbols :: Ptr TS.Language -> IO [(String, Named)]
@@ -92,7 +96,7 @@ symbolMatchingInstance allSymbols name named str = do
   let tsSymbols = elemIndices (str, named) allSymbols
   let names = intercalate ", " $ fmap (debugPrefix . (!!) allSymbols) tsSymbols
   [d|instance TS.SymbolMatching $(conT name) where
-      showFailure _ node = "expected " <> $(litE (stringL (show names))) <> " but got " <> show (debugPrefix (allSymbols !! fromIntegral (nodeSymbol node)))
+      showFailure _ node = "expected " <> $(litE (stringL (show names))) <> " but got " <> show (allSymbolNames !! fromIntegral (nodeSymbol node))
       symbolMatch _ node = elem (nodeSymbol node) tsSymbols|]
 
 -- | Prefix symbol names for debugging to disambiguate between Named and Anonymous nodes.

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -94,7 +94,7 @@ syntaxDatatype language allSymbols datatype = skipDefined $ do
 symbolMatchingInstance :: [(String, Named)] -> Name -> Named -> String -> Q [Dec]
 symbolMatchingInstance allSymbols name named str = do
   let tsSymbols = elemIndices (str, named) allSymbols
-  let names = intercalate ", " $ fmap (debugPrefix . (!!) allSymbols) tsSymbols
+      names = intercalate ", " $ fmap (debugPrefix . (!!) allSymbols) tsSymbols
   [d|instance TS.SymbolMatching $(conT name) where
       showFailure _ node = "expected " <> $(litE (stringL (show names))) <> " but got " <> show (allSymbolNames !! fromIntegral (nodeSymbol node))
       symbolMatch _ node = elem (nodeSymbol node) tsSymbols|]

--- a/tree-sitter/src/TreeSitter/GenerateSyntax.hs
+++ b/tree-sitter/src/TreeSitter/GenerateSyntax.hs
@@ -35,9 +35,9 @@ astDeclarationsForLanguage language filePath = do
   currentFilename <- loc_filename <$> location
   pwd             <- runIO getCurrentDirectory
   let invocationRelativePath = takeDirectory (pwd </> currentFilename) </> filePath
-  input <- runIO (eitherDecodeFileStrict' invocationRelativePath)
+  input <- runIO (eitherDecodeFileStrict' invocationRelativePath) >>= either fail pure
   allSymbols <- runIO (getAllSymbols language)
-  either fail (fmap (concat @[]) . traverse (syntaxDatatype language allSymbols)) input
+  concat @[] <$> traverse (syntaxDatatype language allSymbols) input
 
 -- Build a list of all symbols
 getAllSymbols :: Ptr TS.Language -> IO [(String, Named)]


### PR DESCRIPTION
`TreeSitter.GenerateSyntax` was including the debug-prefixed symbol names in each and every generated `showFailure` method, inadvertently requiring `ghc` to compile that much more code.

This PR instead defines a `debugSymbolNames` binding statically (which is therefore a CAF, with consequent runtime savings, tho if looking up debug symbol names is ever a bottleneck we’ve got other problems to worry about) and looks up node symbols in it in the `showFailure` method definitions.