### PR TITLE
Package up the tree-sitter test corpus

### DIFF
--- a/tree-sitter-go/TreeSitter/Go.hs
+++ b/tree-sitter-go/TreeSitter/Go.hs
@@ -1,6 +1,7 @@
 module TreeSitter.Go
 ( tree_sitter_go
 , getNodeTypesPath
+, getTestCorpusDir
 ) where
 
 import Foreign.Ptr
@@ -11,3 +12,6 @@ foreign import ccall unsafe "vendor/tree-sitter-go/src/parser.c tree_sitter_go" 
 
 getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-go/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-go/corpus"

--- a/tree-sitter-go/tree-sitter-go.cabal
+++ b/tree-sitter-go/tree-sitter-go.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-go
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            Tree-sitter grammar/parser for Go
 description:         This package provides a parser for Go suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -11,6 +11,7 @@ copyright:           2019 GitHub
 category:            Tree-sitter, Go
 build-type:          Simple
 data-files:          vendor/tree-sitter-go/src/node-types.json
+                   , vendor/tree-sitter-go/corpus/*.txt
 extra-source-files:  ChangeLog.md
 
 common common

--- a/tree-sitter-java/TreeSitter/Java.hs
+++ b/tree-sitter-java/TreeSitter/Java.hs
@@ -1,6 +1,7 @@
 module TreeSitter.Java
 ( tree_sitter_java
 , getNodeTypesPath
+, getTestCorpusDir
 ) where
 
 import Foreign.Ptr
@@ -11,3 +12,6 @@ foreign import ccall unsafe "vendor/tree-sitter-java/src/parser.c tree_sitter_ja
 
 getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-java/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-java/corpus"

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-java
-version:             0.7.0.0
+version:             0.7.0.1
 synopsis:            Tree-sitter grammar/parser for Java
 description:         This package provides a parser for Java suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -11,6 +11,7 @@ copyright:           2019 GitHub
 category:            Tree-sitter, Java
 build-type:          Simple
 data-files:          vendor/tree-sitter-java/src/node-types.json
+                   , vendor/tree-sitter-java/corpus/*.txt
 extra-source-files:  ChangeLog.md
 
 common common

--- a/tree-sitter-json/TreeSitter/JSON.hs
+++ b/tree-sitter-json/TreeSitter/JSON.hs
@@ -1,6 +1,7 @@
 module TreeSitter.JSON
 ( tree_sitter_json
 , getNodeTypesPath
+, getTestCorpusDir
 ) where
 
 import Foreign.Ptr
@@ -11,3 +12,6 @@ foreign import ccall unsafe "vendor/tree-sitter-json/src/parser.c tree_sitter_js
 
 getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-json/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-json/corpus"

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-json
-version:             0.7.0.0
+version:             0.7.0.1
 synopsis:            Tree-sitter grammar/parser for JSON
 description:         This package provides a parser for JSON suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-python/TreeSitter/Python.hs
+++ b/tree-sitter-python/TreeSitter/Python.hs
@@ -1,6 +1,7 @@
 module TreeSitter.Python
 ( tree_sitter_python
 , getNodeTypesPath
+, getTestCorpusDir
 ) where
 
 import Foreign.Ptr
@@ -11,3 +12,6 @@ foreign import ccall unsafe "vendor/tree-sitter-python/src/parser.c tree_sitter_
 
 getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-python/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-python/test/corpus"

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-python
-version:             0.9.0.1
+version:             0.9.0.2
 synopsis:            Tree-sitter grammar/parser for Python
 description:         This package provides a parser for Python suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -11,6 +11,7 @@ copyright:           2019 GitHub
 category:            Tree-sitter, Python
 build-type:          Simple
 data-files:          vendor/tree-sitter-python/src/node-types.json
+                   , vendor/tree-sitter-python/test/corpus/*.txt
 extra-source-files:  ChangeLog.md
 
 common common

--- a/tree-sitter-ruby/TreeSitter/Ruby.hs
+++ b/tree-sitter-ruby/TreeSitter/Ruby.hs
@@ -1,6 +1,7 @@
 module TreeSitter.Ruby
 ( tree_sitter_ruby
 , getNodeTypesPath
+, getTestCorpusDir
 ) where
 
 import Foreign.Ptr
@@ -11,3 +12,6 @@ foreign import ccall unsafe "vendor/tree-sitter-ruby/src/parser.c tree_sitter_ru
 
 getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-ruby/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-ruby/test/corpus"

--- a/tree-sitter-ruby/tree-sitter-ruby.cabal
+++ b/tree-sitter-ruby/tree-sitter-ruby.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-ruby
-version:             0.5.0.1
+version:             0.5.0.2
 synopsis:            Tree-sitter grammar/parser for Ruby
 description:         This package provides a parser for Ruby suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -11,6 +11,7 @@ copyright:           2019 GitHub
 category:            Tree-sitter, Ruby
 build-type:          Simple
 data-files:          vendor/tree-sitter-ruby/src/node-types.json
+                   , vendor/tree-sitter-ruby/test/corpus/*.txt
 extra-source-files:  ChangeLog.md
 
 common common

--- a/tree-sitter-tsx/TreeSitter/TSX.hs
+++ b/tree-sitter-tsx/TreeSitter/TSX.hs
@@ -1,6 +1,7 @@
 module TreeSitter.TSX
 ( tree_sitter_tsx
 , getNodeTypesPath
+, getTestCorpusDir
 ) where
 
 import Foreign.Ptr
@@ -11,3 +12,6 @@ foreign import ccall unsafe "vendor/tree-sitter-typescript/tsx/src/parser.c tree
 
 getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-typescript/tsx/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-typescript/tsx/corpus"

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-tsx
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            Tree-sitter grammar/parser for TSX
 description:         This package provides a parser for TSX (TypeScript + XML) suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -11,6 +11,7 @@ copyright:           2019 GitHub
 category:            Tree-sitter, TypeScript
 build-type:          Simple
 data-files:          vendor/tree-sitter-typescript/tsx/src/node-types.json
+                   , vendor/tree-sitter-typescript/tsx/corpus/**/*.txt
 extra-source-files:  ChangeLog.md
 
 common common

--- a/tree-sitter-typescript/TreeSitter/TypeScript.hs
+++ b/tree-sitter-typescript/TreeSitter/TypeScript.hs
@@ -1,6 +1,7 @@
 module TreeSitter.TypeScript
 ( tree_sitter_typescript
 , getNodeTypesPath
+, getTestCorpusDir
 ) where
 
 import Foreign.Ptr
@@ -11,3 +12,6 @@ foreign import ccall unsafe "vendor/tree-sitter-typescript/typescript/src/parser
 
 getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-typescript/typescript/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-typescript/typescript/corpus"

--- a/tree-sitter-typescript/tree-sitter-typescript.cabal
+++ b/tree-sitter-typescript/tree-sitter-typescript.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-typescript
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            Tree-sitter grammar/parser for TypeScript
 description:         This package provides a parser for TypeScript suitable for use with the tree-sitter package.
 license:             BSD-3-Clause
@@ -11,6 +11,7 @@ copyright:           2019 GitHub
 category:            Tree-sitter, TypeScript
 build-type:          Simple
 data-files:          vendor/tree-sitter-typescript/typescript/src/node-types.json
+                   , vendor/tree-sitter-typescript/typescript/corpus/**/*.txt
 extra-source-files:  ChangeLog.md
 
 common common


### PR DESCRIPTION
Includes the tree-sitter test corpus so that dependent packages can leverage these example fixtures as needed. I'll demonstrate usage over on https://github.com/github/semantic next.