### PR TITLE
Add tree-sitter-ql

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "languages/tsx/vendor/tree-sitter-typescript"]
 	path = tree-sitter-tsx/vendor/tree-sitter-typescript
 	url = https://github.com/tree-sitter/tree-sitter-typescript
+[submodule "tree-sitter-ql/vendor/tree-sitter-ql"]
+	path = tree-sitter-ql/vendor/tree-sitter-ql
+	url = https://github.com/tree-sitter/tree-sitter-ql

--- a/tree-sitter-ql/ChangeLog.md
+++ b/tree-sitter-ql/ChangeLog.md
@@ -1,3 +1,3 @@
-# v0.9.0.0
+# v0.9.0.2
 
 * add tree-sitter-ql parser

--- a/tree-sitter-ql/ChangeLog.md
+++ b/tree-sitter-ql/ChangeLog.md
@@ -1,3 +1,3 @@
-# v0.9.0.2
+# v0.1.0.0
 
 * add tree-sitter-ql parser

--- a/tree-sitter-ql/ChangeLog.md
+++ b/tree-sitter-ql/ChangeLog.md
@@ -1,0 +1,3 @@
+# v0.9.0.0
+
+* add tree-sitter-ql parser

--- a/tree-sitter-ql/Setup.hs
+++ b/tree-sitter-ql/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tree-sitter-ql/TreeSitter/QL.hs
+++ b/tree-sitter-ql/TreeSitter/QL.hs
@@ -1,0 +1,17 @@
+module TreeSitter.QL
+( tree_sitter_ql
+, getNodeTypesPath
+, getTestCorpusDir
+) where
+
+import Foreign.Ptr
+import TreeSitter.Language
+import Paths_tree_sitter_ql
+
+foreign import ccall unsafe "vendor/tree-sitter-ql/src/parser.c tree_sitter_ql" tree_sitter_ql :: Ptr Language
+
+getNodeTypesPath :: IO FilePath
+getNodeTypesPath = getDataFileName "vendor/tree-sitter-ql/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-ql/test/corpus"

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -11,7 +11,7 @@ copyright:           2019 GitHub
 category:            Tree-sitter, QL
 build-type:          Simple
 data-files:          vendor/tree-sitter-ql/src/node-types.json
-                   , vendor/tree-sitter-ql/test/corpus/*.txt
+                   , vendor/tree-sitter-ql/corpus/*.txt
 extra-source-files:  ChangeLog.md
 
 common common

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-ql
-version:             0.9.0.2
+version:             0.1.0.0
 synopsis:            Tree-sitter grammar/parser for QL
 description:         This package provides a parser for QL suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -6,8 +6,8 @@ description:         This package provides a parser for QL suitable for use with
 license:             BSD-3-Clause
 homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-ql
 author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
-maintainer:          tclem@github.com
-copyright:           2019 GitHub
+maintainer:          rewinfrey@github.com
+copyright:           2020 GitHub
 category:            Tree-sitter, QL
 build-type:          Simple
 data-files:          vendor/tree-sitter-ql/src/node-types.json
@@ -38,7 +38,7 @@ library
   autogen-modules:     Paths_tree_sitter_ql
   other-modules:       Paths_tree_sitter_ql
   build-depends:       base >= 4.12 && <4.14
-                     , tree-sitter
+                     , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-ql/src
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-ql/src/parser.c

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -1,0 +1,49 @@
+cabal-version:       2.4
+name:                tree-sitter-ql
+version:             0.9.0.2
+synopsis:            Tree-sitter grammar/parser for QL
+description:         This package provides a parser for QL suitable for use with the tree-sitter package.
+license:             BSD-3-Clause
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-ql
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson
+maintainer:          tclem@github.com
+copyright:           2019 GitHub
+category:            Tree-sitter, QL
+build-type:          Simple
+data-files:          vendor/tree-sitter-ql/src/node-types.json
+                   , vendor/tree-sitter-ql/test/corpus/*.txt
+extra-source-files:  ChangeLog.md
+
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
+library
+  import: common
+  exposed-modules:     TreeSitter.QL
+  autogen-modules:     Paths_tree_sitter_ql
+  other-modules:       Paths_tree_sitter_ql
+  build-depends:       base >= 4.12 && <4.14
+                     , tree-sitter
+  Include-dirs:        vendor/tree-sitter-ql/src
+  install-includes:    tree_sitter/parser.h
+  c-sources:           vendor/tree-sitter-ql/src/parser.c
+  extra-libraries:     stdc++
+
+source-repository head
+  type:     git
+  location: https://github.com/tree-sitter/haskell-tree-sitter


### PR DESCRIPTION
This adds support for `tree-sitter-ql`.

~I'm having trouble uploading a `tree-sitter-ql` package to Hackage using `script/build-and-upload`:~

~I think this might be because I'm not in the maintainer's group for `haskell-tree-sitter` and the `source-repository` in `tree-sitter-ql.cabal` lists `haskell-tree-sitter.git` as its source repo.~

~@patrickt any ideas on why I'm seeing a 403 for this upload ☝️ ?~

EDIT:

The package is now live on hackage https://hackage.haskell.org/package/tree-sitter-ql-0.1.0.0

