### PR TITLE
Update tree-sitter-ql to use consistent path to test files

### DIFF
--- a/tree-sitter-ql/ChangeLog.md
+++ b/tree-sitter-ql/ChangeLog.md
@@ -1,3 +1,7 @@
+# v0.1.0.1
+
+* Bump tree-sitter-ql parser to use consistent test structure (test/corpus/*.txt)
+
 # v0.1.0.0
 
 * add tree-sitter-ql parser

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-ql
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Tree-sitter grammar/parser for QL
 description:         This package provides a parser for QL suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -11,7 +11,7 @@ copyright:           2020 GitHub
 category:            Tree-sitter, QL
 build-type:          Simple
 data-files:          vendor/tree-sitter-ql/src/node-types.json
-                   , vendor/tree-sitter-ql/corpus/*.txt
+                   , vendor/tree-sitter-ql/test/corpus/*.txt
 extra-source-files:  ChangeLog.md
 
 common common


### PR DESCRIPTION
While adding the `tree-sitter-ql` package to `semantic`, I noticed that `tree-sitter-ql` had a top-level `corpus` directory rather than the standard `test/corpus` directory structure found in most tree-sitter projects.

This bumps the vendored `tree-sitter-ql` parser and corpus files so that `semantic` can use the standard test file path.