### PR TITLE
Remove semantic source dependency

### DIFF
--- a/tree-sitter/ChangeLog.md
+++ b/tree-sitter/ChangeLog.md
@@ -1,3 +1,7 @@
+### v0.9.0.1
+
+* Remove `semantic-source` dependency.
+
 ### v0.9.0.0
 
 * Remove CodeGen files `Deserialize`, `GenerateSyntax`, `Unmarshal`, `Token`

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -57,7 +57,6 @@ library
                      , text                 ^>= 1.2.3.1
                      , unordered-containers ^>= 0.2.9
                      , containers            >= 0.6.0.1
-                     , semantic-source      ^>= 0.0.0.0
   exposed-modules:     TreeSitter.Parser
                      , TreeSitter.Language
                      , TreeSitter.Node

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter
-version:             0.9.0.0
+version:             0.9.0.1
 synopsis:            Unstable bindings for the tree-sitter parsing library.
 description:         Tree-sitter is a parser generator tool and an incremental parsing library.
                      .


### PR DESCRIPTION
`semantic-source` was required by `tree-sitter`  in the past, but for now `semantic-source` is no longer needed in `tree-sitter`.

@patrickt and I attempted to remove `tree-sitter` from the existing published `semantic-source` package, but Hackage does not support revisions that remove dependencies at this time.

So this patch formalizes the removal of `tree-sitter` and bumps the version to `0.9.0.1`.

