### PR TITLE
Bump tree-sitter-ql to pull in named fields

### DIFF
--- a/tree-sitter-ql/ChangeLog.md
+++ b/tree-sitter-ql/ChangeLog.md
@@ -1,3 +1,7 @@
+# v0.1.0.2
+
+* Bump tree-sitter-ql parser to use named field nodes
+
 # v0.1.0.1
 
 * Bump tree-sitter-ql parser to use consistent test structure (test/corpus/*.txt)

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-ql
-version:             0.1.0.1
+version:             0.1.0.2
 synopsis:            Tree-sitter grammar/parser for QL
 description:         This package provides a parser for QL suitable for use with the tree-sitter package.
 license:             BSD-3-Clause


### PR DESCRIPTION
I've bumped the `tree-sitter-ql` parser to include named field nodes. I think these were lost by accident in previous iterations of the `tree-sitter-ql` grammar. I've also published a new version of [`tree-sitter-ql`](https://hackage.haskell.org/package/tree-sitter-ql-0.1.0.2) to hackage.