### PR TITLE
Update tree-sitter-ql

### DIFF
--- a/tree-sitter-ql/ChangeLog.md
+++ b/tree-sitter-ql/ChangeLog.md
@@ -1,3 +1,7 @@
+# v0.1.0.3
+
+* Bump tree-sitter-ql parser to use named field nodes for module expressions
+
 # v0.1.0.2
 
 * Bump tree-sitter-ql parser to use named field nodes

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-ql
-version:             0.1.0.2
+version:             0.1.0.3
 synopsis:            Tree-sitter grammar/parser for QL
 description:         This package provides a parser for QL suitable for use with the tree-sitter package.
 license:             BSD-3-Clause


### PR DESCRIPTION
This pulls in changes to the `tree-sitter-ql` parser and introduces `name` field nodes for module expressions.

A new [hackage package](https://hackage.haskell.org/package/tree-sitter-ql-0.1.0.3) has been published.