### PR TITLE
Add C# language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "tree-sitter-ql/vendor/tree-sitter-ql"]
 	path = tree-sitter-ql/vendor/tree-sitter-ql
 	url = https://github.com/tree-sitter/tree-sitter-ql
+[submodule "tree-sitter-c-sharp/vendor/tree-sitter-c-sharp"]
+	path = tree-sitter-c-sharp/vendor/tree-sitter-c-sharp
+	url = https://github.com/tree-sitter/tree-sitter-c-sharp

--- a/tree-sitter-c-sharp/ChangeLog.md
+++ b/tree-sitter-c-sharp/ChangeLog.md
@@ -1,0 +1,3 @@
+# v0.1.0.0
+
+* add tree-sitter-c-sharp parser

--- a/tree-sitter-c-sharp/Setup.hs
+++ b/tree-sitter-c-sharp/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tree-sitter-c-sharp/TreeSitter/CSharp.hs
+++ b/tree-sitter-c-sharp/TreeSitter/CSharp.hs
@@ -1,0 +1,17 @@
+module TreeSitter.CSharp
+( tree_sitter_c_sharp
+, getNodeTypesPath
+, getTestCorpusDir
+) where
+
+import Foreign.Ptr
+import TreeSitter.Language
+import Paths_tree_sitter_c_sharp
+
+foreign import ccall unsafe "vendor/tree-sitter-c-sharp/src/parser.c tree_sitter_c_sharp" tree_sitter_c_sharp :: Ptr Language
+
+getNodeTypesPath :: IO FilePath
+getNodeTypesPath = getDataFileName "vendor/tree-sitter-c-sharp/src/node-types.json"
+
+getTestCorpusDir :: IO FilePath
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-c-sharp/test/corpus"

--- a/tree-sitter-c-sharp/TreeSitter/CSharp.hs
+++ b/tree-sitter-c-sharp/TreeSitter/CSharp.hs
@@ -14,4 +14,4 @@ getNodeTypesPath :: IO FilePath
 getNodeTypesPath = getDataFileName "vendor/tree-sitter-c-sharp/src/node-types.json"
 
 getTestCorpusDir :: IO FilePath
-getTestCorpusDir = getDataFileName "vendor/tree-sitter-c-sharp/test/corpus"
+getTestCorpusDir = getDataFileName "vendor/tree-sitter-c-sharp/corpus"

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -1,0 +1,49 @@
+cabal-version:       2.4
+name:                tree-sitter-c-sharp
+version:             0.1.0.0
+synopsis:            Tree-sitter grammar/parser for C#
+description:         This package provides a parser for C# suitable for use with the tree-sitter package.
+license:             BSD-3-Clause
+homepage:            https://github.com/tree-sitter/haskell-tree-sitter/tree/master/tree-sitter-c-sharp
+author:              Max Brunsfeld, Tim Clem, Rob Rix, Josh Vera, Rick Winfrey, Ayman Nadeem, Patrick Thomson, Damien Guard
+maintainer:          damieng@gmail.com
+copyright:           2020 GitHub
+category:            Tree-sitter, CSharp, C#
+build-type:          Simple
+data-files:          vendor/tree-sitter-c-sharp/src/node-types.json
+                   , vendor/tree-sitter-c-sharp/test/corpus/*.txt
+extra-source-files:  ChangeLog.md
+
+common common
+  default-language: Haskell2010
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-import-lists
+    -Wno-missing-local-signatures
+    -Wno-monomorphism-restriction
+    -Wno-name-shadowing
+    -Wno-safe
+    -Wno-unsafe
+  if (impl(ghc >= 8.6))
+    ghc-options: -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options: -Wno-missing-deriving-strategies
+
+library
+  import: common
+  exposed-modules:     TreeSitter.CSharp
+  autogen-modules:     Paths_tree_sitter_c_sharp
+  other-modules:       Paths_tree_sitter_c_sharp
+  build-depends:       base >= 4.12 && <4.14
+                     , tree-sitter ^>= 0.9.0.0
+  Include-dirs:        vendor/tree-sitter-c-sharp/src
+  install-includes:    tree_sitter/parser.h
+  c-sources:           vendor/tree-sitter-c-sharp/src/parser.c
+  extra-libraries:     stdc++
+
+source-repository head
+  type:     git
+  location: https://github.com/tree-sitter/haskell-tree-sitter

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -11,7 +11,7 @@ copyright:           2020 GitHub
 category:            Tree-sitter, CSharp, C#
 build-type:          Simple
 data-files:          vendor/tree-sitter-c-sharp/src/node-types.json
-                   , vendor/tree-sitter-c-sharp/test/corpus/*.txt
+                   , vendor/tree-sitter-c-sharp/corpus/*.txt
 extra-source-files:  ChangeLog.md
 
 common common


### PR DESCRIPTION
Add's C# support here in order to get closer to C# semantic code support on GitHub.com

Not sure how to test this locally but the CI/GH Actions are passing including running the corpus tests.

Let me know if anything else needs to happen either on this repo, tree-sitter-c-sharp or elsewhere!

Fixes #185 