### PR TITLE
Add 8.10.1 support for haskell tree-sitter packages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,11 @@
 packages: tree-sitter tree-sitter-*
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell/text
+  tag: a01843250166b5559936ba5eb81f7873e709587a
+
+source-repository-package
+  type: git
+  location: https://github.com/fused-effects/fused-effects.git
+  tag: a3518b31193d9a53fe8f0a61b2132298964ffc48

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.CSharp
   autogen-modules:     Paths_tree_sitter_c_sharp
   other-modules:       Paths_tree_sitter_c_sharp
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-c-sharp/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-go/tree-sitter-go.cabal
+++ b/tree-sitter-go/tree-sitter-go.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Go
   autogen-modules:     Paths_tree_sitter_go
   other-modules:       Paths_tree_sitter_go
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-go/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-haskell/tree-sitter-haskell.cabal
+++ b/tree-sitter-haskell/tree-sitter-haskell.cabal
@@ -51,7 +51,7 @@ library
   exposed-modules:     TreeSitter.Haskell
   autogen-modules:     Paths_tree_sitter_haskell
   other-modules:       Paths_tree_sitter_haskell
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-haskell/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Java
   autogen-modules:     Paths_tree_sitter_java
   other-modules:       Paths_tree_sitter_java
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-java/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.JSON
   autogen-modules:     Paths_tree_sitter_json
   other-modules:       Paths_tree_sitter_json
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-json/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-nix/tree-sitter-nix.cabal
+++ b/tree-sitter-nix/tree-sitter-nix.cabal
@@ -35,7 +35,7 @@ library
   exposed-modules:     TreeSitter.Nix
   build-depends:       base              >= 4.7 && < 5
                      , tree-sitter       >= 0.3 && < 1
-                     , template-haskell  >= 2.12 && < 2.16
+                     , template-haskell  >= 2.12 && < 2.17
                      , tree-sitter-nix-internal
 
 library tree-sitter-nix-internal

--- a/tree-sitter-php/tree-sitter-php.cabal
+++ b/tree-sitter-php/tree-sitter-php.cabal
@@ -36,7 +36,7 @@ library
   exposed-modules:     TreeSitter.PHP
   autogen-modules:     Paths_tree_sitter_php
   other-modules:       Paths_tree_sitter_php
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-php/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Python
   autogen-modules:     Paths_tree_sitter_python
   other-modules:       Paths_tree_sitter_python
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-python/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.QL
   autogen-modules:     Paths_tree_sitter_ql
   other-modules:       Paths_tree_sitter_ql
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-ql/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-ruby/tree-sitter-ruby.cabal
+++ b/tree-sitter-ruby/tree-sitter-ruby.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Ruby
   autogen-modules:     Paths_tree_sitter_ruby
   other-modules:       Paths_tree_sitter_ruby
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-ruby/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-rust/tree-sitter-rust.cabal
+++ b/tree-sitter-rust/tree-sitter-rust.cabal
@@ -36,7 +36,7 @@ library
   exposed-modules:     TreeSitter.Rust
   autogen-modules:     Paths_tree_sitter_rust
   other-modules:       Paths_tree_sitter_rust
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-rust/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.TSX
   autogen-modules:     Paths_tree_sitter_tsx
   other-modules:       Paths_tree_sitter_tsx
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-typescript/tsx/src
                        vendor/tree-sitter-typescript/common

--- a/tree-sitter-typescript/tree-sitter-typescript.cabal
+++ b/tree-sitter-typescript/tree-sitter-typescript.cabal
@@ -14,6 +14,8 @@ data-files:          vendor/tree-sitter-typescript/typescript/src/node-types.jso
                    , vendor/tree-sitter-typescript/typescript/corpus/**/*.txt
 extra-source-files:  ChangeLog.md
 
+
+
 common common
   default-language: Haskell2010
   ghc-options:
@@ -37,7 +39,7 @@ library
   exposed-modules:     TreeSitter.TypeScript
   autogen-modules:     Paths_tree_sitter_typescript
   other-modules:       Paths_tree_sitter_typescript
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && <4.15
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-typescript/typescript/src
                        vendor/tree-sitter-typescript/common

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -46,15 +46,12 @@ library
   import: common
   hs-source-dirs:      src
   build-depends:       base                  >= 4.12 && < 5
-                     , aeson                ^>= 1.4.2
                      , bytestring           ^>= 0.10.8.2
                      , containers           ^>= 0.6.0.1
                      , directory            ^>= 1.3
                      , filepath             ^>= 1.4.1
-                     , fused-effects        ^>= 1
                      , split                ^>= 0.2.3
-                     , template-haskell      >= 2.12 && < 2.16
-                     , text                 ^>= 1.2.3.1
+                     , template-haskell      >= 2.12 && < 2.17
                      , unordered-containers ^>= 0.2.9
                      , containers            >= 0.6.0.1
   exposed-modules:     TreeSitter.Parser


### PR DESCRIPTION
Adds 8.10.1 support by pinning `text` and `fused-effects` and updating our base bounds.

Leaving this as a Draft PR since we probably want to wait until the upstream packages are published.