### PR TITLE
Ensure trigraphs are ignored when compiling C# parser.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.1"]
-        cabal: ["3.0"]
+        ghc: ["8.6.5", "8.8.3"]
+        cabal: ["3.2.0.0"]
 
     steps:
     - uses: actions/checkout@master

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -43,7 +43,7 @@ library
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-c-sharp/src/parser.c
   extra-libraries:     stdc++
-  cc-options:          -fno-trigraphs -Wno-trigraphs
+  cc-options:          -Wno-trigraphs
 
 source-repository head
   type:     git

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -43,6 +43,7 @@ library
   install-includes:    tree_sitter/parser.h
   c-sources:           vendor/tree-sitter-c-sharp/src/parser.c
   extra-libraries:     stdc++
+  cc-options:          -fno-trigraphs -Wno-trigraphs
 
 source-repository head
   type:     git


### PR DESCRIPTION
Ironically, the relevant `??=` glyph compiles to `#`!

Fixes #284.