### PR TITLE
Drop dependency on fused effects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.3"]
+        ghc: ["8.6.5", "8.8.3", "8.10.1"]
         cabal: ["3.2.0.0"]
 
     steps:

--- a/tree-sitter-c-sharp/ChangeLog.md
+++ b/tree-sitter-c-sharp/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.1.0.1
+
+* Support ghc 8.10.
+
+
 # v0.1.0.0
 
 * add tree-sitter-c-sharp parser

--- a/tree-sitter-c-sharp/ChangeLog.md
+++ b/tree-sitter-c-sharp/ChangeLog.md
@@ -1,8 +1,3 @@
-# v0.1.0.1
-
-* Support ghc 8.10.
-
-
 # v0.1.0.0
 
 * add tree-sitter-c-sharp parser

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-c-sharp
-version:             0.1.0.1
+version:             0.1.0.0
 synopsis:            Tree-sitter grammar/parser for C#
 description:         This package provides a parser for C# suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-c-sharp
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Tree-sitter grammar/parser for C#
 description:         This package provides a parser for C# suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
+++ b/tree-sitter-c-sharp/tree-sitter-c-sharp.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.CSharp
   autogen-modules:     Paths_tree_sitter_c_sharp
   other-modules:       Paths_tree_sitter_c_sharp
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-c-sharp/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-go/ChangeLog.md
+++ b/tree-sitter-go/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.5.0.2
+
+* Support ghc 8.10.
+
+
 # v0.5.0.0
 
 * remove CodeGen and Template Haskell splice

--- a/tree-sitter-go/tree-sitter-go.cabal
+++ b/tree-sitter-go/tree-sitter-go.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-go/tree-sitter-go.cabal
+++ b/tree-sitter-go/tree-sitter-go.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-go
-version:             0.5.0.1
+version:             0.5.0.2
 synopsis:            Tree-sitter grammar/parser for Go
 description:         This package provides a parser for Go suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-go/tree-sitter-go.cabal
+++ b/tree-sitter-go/tree-sitter-go.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Go
   autogen-modules:     Paths_tree_sitter_go
   other-modules:       Paths_tree_sitter_go
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-go/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-haskell/ChangeLog.md
+++ b/tree-sitter-haskell/ChangeLog.md
@@ -1,4 +1,9 @@
-#v0.3.0.0
+# v0.3.0.1
+
+* Support ghc 8.10.
+
+
+# v0.3.0.0
 
 * remove CodeGen and Template Haskell splice
 * move contents of internal library into library and remove internal library

--- a/tree-sitter-haskell/tree-sitter-haskell.cabal
+++ b/tree-sitter-haskell/tree-sitter-haskell.cabal
@@ -29,6 +29,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 flag build-examples
   description: Build tree-sitter-haskell examples.

--- a/tree-sitter-haskell/tree-sitter-haskell.cabal
+++ b/tree-sitter-haskell/tree-sitter-haskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-haskell
-version:             0.3.0.0
+version:             0.3.0.1
 synopsis:            Tree-sitter grammar/parser for Haskell (with GHC extensions)
 description:         This package provides a parser for Haskell suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-haskell/tree-sitter-haskell.cabal
+++ b/tree-sitter-haskell/tree-sitter-haskell.cabal
@@ -51,7 +51,7 @@ library
   exposed-modules:     TreeSitter.Haskell
   autogen-modules:     Paths_tree_sitter_haskell
   other-modules:       Paths_tree_sitter_haskell
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-haskell/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-java/ChangeLog.md
+++ b/tree-sitter-java/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.7.0.2
+
+* Support ghc 8.10.
+
+
 # v0.7.0.0
 
 * remove CodeGen and Template Haskell splice

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Java
   autogen-modules:     Paths_tree_sitter_java
   other-modules:       Paths_tree_sitter_java
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-java/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-java/tree-sitter-java.cabal
+++ b/tree-sitter-java/tree-sitter-java.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-java
-version:             0.7.0.1
+version:             0.7.0.2
 synopsis:            Tree-sitter grammar/parser for Java
 description:         This package provides a parser for Java suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-json/ChangeLog.md
+++ b/tree-sitter-json/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.7.0.2
+
+* Support ghc 8.10.
+
+
 # v0.7.0.0
 
 * remove CodeGen and Template Haskell splice

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.JSON
   autogen-modules:     Paths_tree_sitter_json
   other-modules:       Paths_tree_sitter_json
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-json/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-json/tree-sitter-json.cabal
+++ b/tree-sitter-json/tree-sitter-json.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-json
-version:             0.7.0.1
+version:             0.7.0.2
 synopsis:            Tree-sitter grammar/parser for JSON
 description:         This package provides a parser for JSON suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-nix/tree-sitter-nix.cabal
+++ b/tree-sitter-nix/tree-sitter-nix.cabal
@@ -35,7 +35,7 @@ library
   exposed-modules:     TreeSitter.Nix
   build-depends:       base              >= 4.7 && < 5
                      , tree-sitter       >= 0.3 && < 1
-                     , template-haskell  >= 2.12 && < 2.16
+                     , template-haskell  >= 2.12 && < 2.17
                      , tree-sitter-nix-internal
 
 library tree-sitter-nix-internal

--- a/tree-sitter-nix/tree-sitter-nix.cabal
+++ b/tree-sitter-nix/tree-sitter-nix.cabal
@@ -29,6 +29,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-ocaml/tree-sitter-ocaml.cabal
+++ b/tree-sitter-ocaml/tree-sitter-ocaml.cabal
@@ -36,7 +36,7 @@ library
   exposed-modules:     TreeSitter.OCaml
   autogen-modules:     Paths_tree_sitter_ocaml
   other-modules:       Paths_tree_sitter_ocaml
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-ocaml/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-ocaml/tree-sitter-ocaml.cabal
+++ b/tree-sitter-ocaml/tree-sitter-ocaml.cabal
@@ -30,6 +30,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-php/ChangeLog.md
+++ b/tree-sitter-php/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.5.0.1
+
+* Support ghc 8.10.
+
+
 # v0.5.0.0
 
 * Major version bump since parser and symbols changed.

--- a/tree-sitter-php/tree-sitter-php.cabal
+++ b/tree-sitter-php/tree-sitter-php.cabal
@@ -36,7 +36,7 @@ library
   exposed-modules:     TreeSitter.PHP
   autogen-modules:     Paths_tree_sitter_php
   other-modules:       Paths_tree_sitter_php
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-php/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-php/tree-sitter-php.cabal
+++ b/tree-sitter-php/tree-sitter-php.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                tree-sitter-php
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            Tree-sitter grammar/parser for PHP
 description:         This package provides a parser for PHP suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-php/tree-sitter-php.cabal
+++ b/tree-sitter-php/tree-sitter-php.cabal
@@ -30,6 +30,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-python/ChangeLog.md
+++ b/tree-sitter-python/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.9.0.3
+
+* Support ghc 8.10.
+
+
 # v0.9.0.1
 
 * fix file path for `node-types.json`

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Python
   autogen-modules:     Paths_tree_sitter_python
   other-modules:       Paths_tree_sitter_python
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-python/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-python/tree-sitter-python.cabal
+++ b/tree-sitter-python/tree-sitter-python.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-python
-version:             0.9.0.2
+version:             0.9.0.3
 synopsis:            Tree-sitter grammar/parser for Python
 description:         This package provides a parser for Python suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-ql/ChangeLog.md
+++ b/tree-sitter-ql/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.1.0.4
+
+* Support ghc 8.10.
+
+
 # v0.1.0.3
 
 * Bump tree-sitter-ql parser to use named field nodes for module expressions

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-ql
-version:             0.1.0.3
+version:             0.1.0.4
 synopsis:            Tree-sitter grammar/parser for QL
 description:         This package provides a parser for QL suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-ql/tree-sitter-ql.cabal
+++ b/tree-sitter-ql/tree-sitter-ql.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.QL
   autogen-modules:     Paths_tree_sitter_ql
   other-modules:       Paths_tree_sitter_ql
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-ql/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-ruby/ChangeLog.md
+++ b/tree-sitter-ruby/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.5.0.3
+
+* Support ghc 8.10.
+
+
 # v0.5.0.1
 
 * fix file path for `node-types.json`

--- a/tree-sitter-ruby/tree-sitter-ruby.cabal
+++ b/tree-sitter-ruby/tree-sitter-ruby.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-ruby/tree-sitter-ruby.cabal
+++ b/tree-sitter-ruby/tree-sitter-ruby.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-ruby
-version:             0.5.0.2
+version:             0.5.0.3
 synopsis:            Tree-sitter grammar/parser for Ruby
 description:         This package provides a parser for Ruby suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-ruby/tree-sitter-ruby.cabal
+++ b/tree-sitter-ruby/tree-sitter-ruby.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.Ruby
   autogen-modules:     Paths_tree_sitter_ruby
   other-modules:       Paths_tree_sitter_ruby
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-ruby/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-rust/ChangeLog.md
+++ b/tree-sitter-rust/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.1.0.1
+
+* Support ghc 8.10.
+
+
 # v0.1.0.0
 
 * add tree-sitter-rust parser

--- a/tree-sitter-rust/tree-sitter-rust.cabal
+++ b/tree-sitter-rust/tree-sitter-rust.cabal
@@ -36,7 +36,7 @@ library
   exposed-modules:     TreeSitter.Rust
   autogen-modules:     Paths_tree_sitter_rust
   other-modules:       Paths_tree_sitter_rust
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter ^>= 0.9.0.0
   Include-dirs:        vendor/tree-sitter-rust/src
   install-includes:    tree_sitter/parser.h

--- a/tree-sitter-rust/tree-sitter-rust.cabal
+++ b/tree-sitter-rust/tree-sitter-rust.cabal
@@ -30,6 +30,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-rust/tree-sitter-rust.cabal
+++ b/tree-sitter-rust/tree-sitter-rust.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-rust
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Tree-sitter grammar/parser for Rust
 description:         This package provides a parser for Rust suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-tsx/ChangeLog.md
+++ b/tree-sitter-tsx/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.5.0.2
+
+* Support ghc 8.10.
+
+
 # v0.5.0.0
 
 * remove CodeGen and Template Haskell splice

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-tsx
-version:             0.5.0.1
+version:             0.5.0.2
 synopsis:            Tree-sitter grammar/parser for TSX
 description:         This package provides a parser for TSX (TypeScript + XML) suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-tsx/tree-sitter-tsx.cabal
+++ b/tree-sitter-tsx/tree-sitter-tsx.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.TSX
   autogen-modules:     Paths_tree_sitter_tsx
   other-modules:       Paths_tree_sitter_tsx
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   Include-dirs:        vendor/tree-sitter-typescript/tsx/src
                        vendor/tree-sitter-typescript/common

--- a/tree-sitter-typescript/ChangeLog.md
+++ b/tree-sitter-typescript/ChangeLog.md
@@ -1,3 +1,8 @@
+# v0.5.0.2
+
+* Support ghc 8.10.
+
+
 # v0.5.0.0
 
 * remove CodeGen and Template Haskell splice

--- a/tree-sitter-typescript/tree-sitter-typescript.cabal
+++ b/tree-sitter-typescript/tree-sitter-typescript.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter-typescript
-version:             0.5.0.1
+version:             0.5.0.2
 synopsis:            Tree-sitter grammar/parser for TypeScript
 description:         This package provides a parser for TypeScript suitable for use with the tree-sitter package.
 license:             BSD-3-Clause

--- a/tree-sitter-typescript/tree-sitter-typescript.cabal
+++ b/tree-sitter-typescript/tree-sitter-typescript.cabal
@@ -31,6 +31,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter-typescript/tree-sitter-typescript.cabal
+++ b/tree-sitter-typescript/tree-sitter-typescript.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:     TreeSitter.TypeScript
   autogen-modules:     Paths_tree_sitter_typescript
   other-modules:       Paths_tree_sitter_typescript
-  build-depends:       base >= 4.12 && <4.14
+  build-depends:       base >= 4.12 && < 5
                      , tree-sitter
   include-dirs:        vendor/tree-sitter-typescript/typescript/src
                        vendor/tree-sitter-typescript/common

--- a/tree-sitter/ChangeLog.md
+++ b/tree-sitter/ChangeLog.md
@@ -1,3 +1,9 @@
+### v0.9.0.2
+
+* Remove `fused-effects` dependency.
+* Support ghc 8.10.
+
+
 ### v0.9.0.1
 
 * Remove `semantic-source` dependency.

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -51,7 +51,6 @@ library
                      , containers           ^>= 0.6.0.1
                      , directory            ^>= 1.3
                      , filepath             ^>= 1.4.1
-                     , fused-effects        ^>= 1
                      , split                ^>= 0.2.3
                      , template-haskell      >= 2.12 && < 2.17
                      , text                 ^>= 1.2.3.1

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                tree-sitter
-version:             0.9.0.1
+version:             0.9.0.2
 synopsis:            Unstable bindings for the tree-sitter parsing library.
 description:         Tree-sitter is a parser generator tool and an incremental parsing library.
                      .

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -53,7 +53,7 @@ library
                      , filepath             ^>= 1.4.1
                      , fused-effects        ^>= 1
                      , split                ^>= 0.2.3
-                     , template-haskell      >= 2.12 && < 2.16
+                     , template-haskell      >= 2.12 && < 2.17
                      , text                 ^>= 1.2.3.1
                      , unordered-containers ^>= 0.2.9
                      , containers            >= 0.6.0.1

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -19,6 +19,7 @@ build-type:          Simple
 tested-with:
   GHC == 8.6.5
   GHC == 8.8.3
+  GHC == 8.10.1
 
 extra-source-files:  vendor/tree-sitter/lib/src/**/*.c
                    , vendor/tree-sitter/lib/src/**/*.h

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -41,6 +41,10 @@ common common
     ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
+  if (impl(ghc >= 8.10))
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
 
 library
   import: common

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -50,14 +50,12 @@ library
   import: common
   hs-source-dirs:      src
   build-depends:       base                  >= 4.12 && < 5
-                     , aeson                ^>= 1.4.2
                      , bytestring           ^>= 0.10.8.2
                      , containers           ^>= 0.6.0.1
                      , directory            ^>= 1.3
                      , filepath             ^>= 1.4.1
                      , split                ^>= 0.2.3
                      , template-haskell      >= 2.12 && < 2.17
-                     , text                 ^>= 1.2.3.1
                      , unordered-containers ^>= 0.2.9
                      , containers            >= 0.6.0.1
   exposed-modules:     TreeSitter.Parser

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -18,7 +18,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 8.6.5
-  GHC == 8.8.1
+  GHC == 8.8.3
 
 extra-source-files:  vendor/tree-sitter/lib/src/**/*.c
                    , vendor/tree-sitter/lib/src/**/*.h


### PR DESCRIPTION
This PR:

- [x] Drops the unused dependency on `fused-effects`.
- [x] Loosens a bunch of bounds on `base` and `template-haskell` to admit ghc 8.10.
- [x] Subsumes #282.