### PR TITLE
Add reserved names

### DIFF
--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -65,7 +65,12 @@ addTickIfNecessary s
   | otherwise = s
   where
     reservedNames :: HashSet.HashSet String
-    reservedNames = HashSet.fromList ["type", "module", "data"]
+    reservedNames = HashSet.fromList [
+        "as", "case", "class", "data", "default", "deriving", "do", "forall",
+        "foreign", "hiding", "if", "then", "else", "import", "infix", "infixl",
+        "infixr", "instance", "let", "in", "mdo", "module", "newtype", "proc",
+        "qualified", "rec", "type", "where"
+      ]
 
 toHaskellPascalCaseIdentifier :: String -> String
 toHaskellPascalCaseIdentifier = addTickIfNecessary . capitalize . escapeOperatorPunctuation . camelCase

--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -108,6 +108,7 @@ escapeOperatorPunctuation = concatMap $ \case
   '\t' -> "Tab"
   '\n' -> "LF"
   '\r' -> "CR"
+  ' ' -> "Space"
   other
     | isControl other -> escapeOperatorPunctuation (show other)
     | otherwise -> [other]


### PR DESCRIPTION
I added some reserved names that should be avoided as haskell identifier. I took the list from https://wiki.haskell.org/Keywords.
The space character was missing from the list of special characters.

The field names `class` and `default`, and the anonymous node `" "` currently occur in [tree-sitter-ocaml](https://github.com/tree-sitter/tree-sitter-ocaml).

Another problem that I encountered is that some supertypes (e.g. [`_sequence_expression`](https://github.com/tree-sitter/tree-sitter-ocaml/blob/ac885cabeeec4d8b5ed1dcd577533b0b549496fe/grammar.js#L965)) are too similar to other nodes (`sequence_expression`) and result in the same identifier. I don't think this can be solved by haskell-tree-sitter in a backwards compatible way, so this should probably be forbidden by tree-sitter (and documented).