### PR TITLE
Rename supertype identifiers

### DIFF
--- a/tree-sitter/src/TreeSitter/Symbol.hs
+++ b/tree-sitter/src/TreeSitter/Symbol.hs
@@ -122,10 +122,12 @@ escapeOperatorPunctuation = concatMap $ \case
 camelCase :: String -> String
 camelCase = go
   where
-    go ('_':'_':xs) = "Underscore" <> go xs
-    go ('_':xs)     = go (capitalize xs)
-    go (x:xs)       = x : go xs
-    go ""           = ""
+    go ('_':xs)      = "super" <> capitalize (go xs)
+    go xs            = go' xs
+    go' ('_':'_':xs) = "Underscore" <> go' (capitalize xs)
+    go' ('_':xs)     = go' (capitalize xs)
+    go' (x:xs)       = x : go' xs
+    go' ""           = ""
 
 -- | Capitalize a String
 capitalize :: String -> String


### PR DESCRIPTION
This solves the problem mentioned in #290. Supertypes with similar names to other nodes (e.g. `_sequence_expression` and `sequence_expression`) result in the same identifier (`SequenceExpression`).

I solved this by prefixing names that start with `_` with `Super`. These are always supertypes, since other names starting with an underscore are invisible in the AST.

Some examples of the new behaviour:
```haskell
toHaskellCamelCaseIdentifier "expression" = "expression"
toHaskellCamelCaseIdentifier "sequence_expression" = "sequenceExpression"
toHaskellCamelCaseIdentifier "_sequence_expression" = "superSequenceExpression"
toHaskellCamelCaseIdentifier "__sequence_expression" = "superSuperSequenceExpression"
toHaskellCamelCaseIdentifier "__sequence__expression" = "superSuperSequenceUnderscoreExpression"

toHaskellPascalCaseIdentifier "expression" = "Expression"
toHaskellPascalCaseIdentifier "sequence_expression" = "SequenceExpression"
toHaskellPascalCaseIdentifier "_sequence_expression" = "SuperSequenceExpression"
toHaskellPascalCaseIdentifier "__sequence_expression" = "SuperSuperSequenceExpression"
toHaskellPascalCaseIdentifier "__sequence__expression" = "SuperSuperSequenceUnderscoreExpression"
```