### PR TITLE
Fix tree-sitter-haskell example

### DIFF
--- a/tree-sitter-haskell/examples/Demo.hs
+++ b/tree-sitter-haskell/examples/Demo.hs
@@ -72,9 +72,9 @@ printChildren children count = forM_
   )
 
 printNode :: Node -> IO ()
-printNode Node {..} = do
+printNode n@(Node {..}) = do
   theType <- peekCString nodeType
-  let TSPoint {..} = nodeStartPoint
+  let TSPoint {..} = nodeStartPoint n
       start        = "(" ++ show pointRow ++ "," ++ show pointColumn ++ ")"
   let TSPoint {..} = nodeEndPoint
       end          = "(" ++ show pointRow ++ "," ++ show pointColumn ++ ")"


### PR DESCRIPTION
[tree-sitter-haskell/examples/Demo.hs](https://github.com/tree-sitter/haskell-tree-sitter/blob/master/tree-sitter-haskell/examples/Demo.hs) fails to compile with the following error:
```
    • Couldn't match expected type ‘Node -> TSPoint’
                  with actual type ‘TSPoint’
    • In the pattern: TSPoint {..}
      In a pattern binding: TSPoint {..} = nodeStartPoint
      In the expression:
        do theType <- peekCString nodeType
           let TSPoint {..} = nodeStartPoint
               start = "(" ++ show pointRow ++ "," ++ show pointColumn ++ ")"
           let TSPoint {..} = nodeEndPoint
               end = "(" ++ show pointRow ++ "," ++ show pointColumn ++ ")"
           print $ theType ++ start ++ "-" ++ end
   |
82 |   let TSPoint {..} = nodeStartPoint
   |       ^^^^^^^^^^^^
```

The problem is tat since 8ae40b366f9a615b58f2a171a801f6cd0fa12325 `nodeStartPoint` is not a field but a separate function and requires a `Node` as an argument.