### PR TITLE
Generate test matrix from tested-with GHCs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,49 +9,56 @@ on:
       - "master"
 
 jobs:
-  build:
-    name: ghc ${{ matrix.ghc }}
+  generateMatrix:
+    name: "Generate matrix from cabal"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ghc: ["8.10", "9.0", "9.2"]
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout base repo
+        uses: actions/checkout@v2
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        run: |
+          wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.5.0/get-tested-0.1.5.0-linux-amd64 -O get-tested
+          chmod +x get-tested
+          ./get-tested --ubuntu tree-sitter/tree-sitter.cabal >> $GITHUB_OUTPUT
+  build:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}                                                                         
+    needs: generateMatrix                                                                                               
+    runs-on: ${{ matrix.os }}                                                                                           
+    strategy:                                                                                                           
+      matrix: ${{ fromJSON(needs.generateMatrix.outputs.matrix) }}
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
-
     - uses: haskell/actions/setup@v1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-
-    - uses: actions/cache@v2
-      name: Cache ~/.cabal/packages
+    - name: Cache
+      uses: actions/cache@v3.3.2
       with:
-        path: ~/.cabal/packages
-        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages
-    - uses: actions/cache@v2
-      name: Cache ~/.cabal/store
-      with:
-        path: ~/.cabal/store
-        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/plan.json') }}
+        restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
     - uses: actions/cache@v2
       name: Cache dist-newstyle
       with:
         path: dist-newstyle
         key: ${{ runner.os }}-${{ matrix.ghc }}-repo-dist
-
     - name: Install dependencies
       run: |
         git submodule update -i --recursive
-        cabal v2-update
-        cabal v2-configure --enable-benchmarks --enable-tests --write-ghc-environment-files=always -j2 -O0
-        cabal v2-build --only-dependencies all
+        cabal update
+        cabal configure --enable-benchmarks --enable-tests --write-ghc-environment-files=always -j2 -O0
+        cabal build --only-dependencies all
 
     - name: Build & test
       run: |
-        cabal v2-build all
-        cabal v2-test all
-        cabal v2-haddock all
-        cabal v2-sdist all
+        cabal build all
+        cabal test all
+        cabal haddock all
+        cabal sdist all
         for p in tree-sitter* ; do echo "$p" ; cd "$p" ; cabal check ; cd ..; done

--- a/tree-sitter/ChangeLog.md
+++ b/tree-sitter/ChangeLog.md
@@ -1,3 +1,8 @@
+### v0.9.0.3
+
+* Support `base-4.14` at least (GHC 8.10.7)
+* Support latest minor versions of 8.10, 9.0, 9.2 and 9.4
+
 ### v0.9.0.2
 
 * Remove `fused-effects` dependency.

--- a/tree-sitter/tree-sitter.cabal
+++ b/tree-sitter/tree-sitter.cabal
@@ -17,9 +17,10 @@ category:            Parsing, Tree-sitter
 build-type:          Simple
 
 tested-with:
-  GHC == 8.10.1
-  GHC == 9.0.1
-  GHC == 9.2.1
+  GHC == 8.10.7
+  GHC == 9.0.2
+  GHC == 9.2.8
+  GHC == 9.4.8
 
 extra-source-files:  vendor/tree-sitter/lib/src/**/*.c
                    , vendor/tree-sitter/lib/src/**/*.h
@@ -38,14 +39,10 @@ common common
     -Wno-name-shadowing
     -Wno-safe
     -Wno-unsafe
-  if (impl(ghc >= 8.6))
-    ghc-options: -Wno-star-is-type
-  if (impl(ghc >= 8.8))
-    ghc-options: -Wno-missing-deriving-strategies
-  if (impl(ghc >= 8.10))
-    ghc-options:
-      -Wno-missing-safe-haskell-mode
-      -Wno-prepositive-qualified-module
+    -Wno-star-is-type
+    -Wno-missing-deriving-strategies
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
   if (impl(ghc >= 9.2))
     ghc-options:
       -Wno-missing-kind-signatures
@@ -55,7 +52,7 @@ library
   import: common
   hs-source-dirs:      src
   build-depends:
-    , base                  >= 4.12 && < 5
+    , base                  >= 4.14.3.0 && < 5
     , bytestring            >= 0.10.8.2 && < 0.13
     , containers           ^>= 0.6.0.1
     , directory            ^>= 1.3


### PR DESCRIPTION
This PR updates the CI setup a bit:

* The `tested-with` stanza of the cabal file is updated to reflect a canonical list of GHC versions that are being actively tested.

* This list is used to generate a CI matrix.

* Supported `base` version is set to 4.14 / GHC 8.10.7, which makes some conditionals like ` if (impl(ghc >= 8.6))` redundant.

* A dependabot config has been setup to offer PR to update the github actions used.